### PR TITLE
fix: when i hit C to check off an item in the queue, it doesn't cross out the item in the tree.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import {
   deleteNodeWithChildren,
   deleteNodeKeepChildren,
   deleteCheckedNodes,
+  ensureIds,
+  findNodeById,
 } from './actions';
 import ChildCount from './components/ChildCount';
 import Linkify from './components/Linkify';
@@ -204,6 +206,7 @@ export default function App({ session }) {
         }
         const data = existing;
         if (data) {
+          ensureIds(data);
           setTree(data);
           setPath([]);
           setSelectedIndex(0);
@@ -212,25 +215,30 @@ export default function App({ session }) {
           const content = await window.treenote.getDefaultFile();
           if (content) {
             const parsed = parseTree(content);
+            ensureIds(parsed);
             setTree(parsed);
             setPath([]);
             setSelectedIndex(0);
             // Save local data to cloud
             saveUserTree(userId, parsed).catch(() => {});
           } else {
-            setTree([{ text: 'Welcome to Treenote', checked: false, children: [
+            const defaultTree = [{ text: 'Welcome to Treenote', checked: false, children: [
               { text: 'Use arrow keys to navigate', checked: false, children: [] },
               { text: 'Press Enter to edit', checked: false, children: [] },
               { text: 'Press Cmd+Down to add items', checked: false, children: [] },
-            ]}]);
+            ]}];
+            ensureIds(defaultTree);
+            setTree(defaultTree);
           }
         } else {
           // New cloud user on web — default tree
-          setTree([{ text: 'Welcome to Treenote', checked: false, children: [
+          const defaultTree = [{ text: 'Welcome to Treenote', checked: false, children: [
             { text: 'Use arrow keys to navigate', checked: false, children: [] },
             { text: 'Press Enter to edit', checked: false, children: [] },
             { text: 'Press Cmd+Down to add items', checked: false, children: [] },
-          ]}]);
+          ]}];
+          ensureIds(defaultTree);
+          setTree(defaultTree);
         }
         loadedRef.current = true;
       }).catch(() => {
@@ -296,6 +304,7 @@ export default function App({ session }) {
     const reader = new FileReader();
     reader.onload = (ev) => {
       const parsed = parseTree(ev.target.result);
+      ensureIds(parsed);
       setTree(parsed);
       setPath([]);
       setSelectedIndex(0);
@@ -328,8 +337,9 @@ export default function App({ session }) {
           const newText = queueEditRef.current.value.trim();
           const item = queue[queueIndex];
           setQueue(q => q.map((it, idx) => idx === queueIndex ? { ...it, text: newText } : it));
-          if (item && item.type === 'ref') {
-            applyAction(editNodeText(tree, item.path, item.index, newText));
+          if (item && item.type === 'ref' && item.nodeId) {
+            const found = findNodeById(tree, item.nodeId);
+            if (found) applyAction(editNodeText(tree, found.path, found.index, newText));
           }
         }
         setMode('visual');
@@ -421,8 +431,9 @@ export default function App({ session }) {
         onUpdateText={(i, text) => {
           const item = queue[i];
           setQueue(q => q.map((it, idx) => idx === i ? { ...it, text } : it));
-          if (item.type === 'ref') {
-            applyAction(editNodeText(tree, item.path, item.index, text));
+          if (item.type === 'ref' && item.nodeId) {
+            const found = findNodeById(tree, item.nodeId);
+            if (found) applyAction(editNodeText(tree, found.path, found.index, text));
           }
         }}
         onExitEdit={() => setMode('visual')}
@@ -604,7 +615,9 @@ export default function App({ session }) {
                 setTimeout(() => setToast(null), 1000);
                 window.treenote.getDefaultFile().then((content) => {
                   if (content) {
-                    setTree(parseTree(content));
+                    const parsed = parseTree(content);
+                    ensureIds(parsed);
+                    setTree(parsed);
                     setPath([]);
                     setSelectedIndex(0);
                     setUndoStack([]);
@@ -621,6 +634,7 @@ export default function App({ session }) {
           userId={userId}
           onClose={() => setBackupOpen(false)}
           onRestore={(treeData) => {
+            ensureIds(treeData);
             setTree(treeData);
             setPath([]);
             setSelectedIndex(0);

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,11 @@
 // Tree action helpers
 // Each action takes the current tree + location, returns { tree, path, selectedIndex }
 
+let _idCounter = 0;
+function generateId() {
+  return Date.now().toString(36) + '-' + (++_idCounter).toString(36);
+}
+
 function cloneTree(tree) {
   return JSON.parse(JSON.stringify(tree));
 }
@@ -18,7 +23,31 @@ function getNodeAt(tree, path, index) {
 }
 
 function newNode(text = '') {
-  return { text, checked: false, children: [] };
+  return { text, checked: false, children: [], id: generateId() };
+}
+
+// Add IDs to any nodes that don't have one (migration for existing data)
+function ensureIds(nodes) {
+  if (!nodes) return;
+  for (const node of nodes) {
+    if (!node.id) node.id = generateId();
+    ensureIds(node.children);
+  }
+}
+
+// Find a node by ID anywhere in the tree. Returns { node, path, index } or null.
+function findNodeById(tree, nodeId) {
+  function search(nodes, currentPath) {
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i].id === nodeId) {
+        return { node: nodes[i], path: currentPath, index: i };
+      }
+      const found = search(nodes[i].children, [...currentPath, i]);
+      if (found) return found;
+    }
+    return null;
+  }
+  return search(tree, []);
 }
 
 // Edit the text of the selected node
@@ -234,4 +263,4 @@ export function toggleMarkdown(tree, path, selectedIndex) {
   return { tree: newTree, path, selectedIndex };
 }
 
-export { cloneTree, getNodeAt, getNodesAt };
+export { cloneTree, getNodeAt, getNodesAt, ensureIds, findNodeById };

--- a/src/components/QueueBar.jsx
+++ b/src/components/QueueBar.jsx
@@ -1,17 +1,5 @@
+import { findNodeById } from '../actions';
 import './QueueBar.css';
-
-function resolveNodeFromTree(tree, path, index) {
-  if (!tree) return null;
-  try {
-    let nodes = tree;
-    for (const idx of path) {
-      nodes = nodes[idx].children;
-    }
-    return nodes[index] || null;
-  } catch {
-    return null;
-  }
-}
 
 export default function QueueBar({ queue, queueIndex, focus, mode, ejecting, queueEditRef, tree, onSelectItem, onUpdateText, onExitEdit }) {
   return (
@@ -23,7 +11,8 @@ export default function QueueBar({ queue, queueIndex, focus, mode, ejecting, que
             {queue.map((item, i) => {
               const isSelected = focus === 'queue' && i === queueIndex;
               const isEditing = isSelected && mode === 'edit';
-              const treeNode = item.type === 'ref' ? resolveNodeFromTree(tree, item.path, item.index) : null;
+              const resolved = item.type === 'ref' && item.nodeId && tree ? findNodeById(tree, item.nodeId) : null;
+              const treeNode = resolved ? resolved.node : null;
               const displayText = treeNode ? treeNode.text : item.text;
               const displayChecked = treeNode ? treeNode.checked : item.checked;
               return (

--- a/src/hooks/useKeyboard.js
+++ b/src/hooks/useKeyboard.js
@@ -14,6 +14,7 @@ import {
   moveToParentLevel,
   moveToSibling,
   toggleMarkdown,
+  findNodeById,
 } from '../actions';
 
 export default function useKeyboard({
@@ -159,13 +160,15 @@ export default function useKeyboard({
               if (item.checked) {
                 setQueue(q => q.map((it, idx) => idx === queueIndex ? { ...it, checked: false } : it));
                 // Sync uncheck to tree for ref items
-                if (item.type === 'ref') {
-                  applyAction(toggleChecked(tree, item.path, item.index));
+                if (item.type === 'ref' && item.nodeId) {
+                  const found = findNodeById(tree, item.nodeId);
+                  if (found) applyAction(toggleChecked(tree, found.path, found.index));
                 }
               } else {
                 // Sync check to tree for ref items
-                if (item.type === 'ref') {
-                  applyAction(toggleChecked(tree, item.path, item.index));
+                if (item.type === 'ref' && item.nodeId) {
+                  const found = findNodeById(tree, item.nodeId);
+                  if (found) applyAction(toggleChecked(tree, found.path, found.index));
                 }
                 ejectQueueItem(queueIndex);
               }
@@ -190,11 +193,13 @@ export default function useKeyboard({
             break;
           case 'q':
             e.preventDefault();
-            if (queue[queueIndex] && queue[queueIndex].type === 'ref') {
-              const item = queue[queueIndex];
-              setPath(item.path);
-              setSelectedIndex(item.index);
-              setFocus('graph');
+            if (queue[queueIndex] && queue[queueIndex].type === 'ref' && queue[queueIndex].nodeId) {
+              const found = findNodeById(tree, queue[queueIndex].nodeId);
+              if (found) {
+                setPath(found.path);
+                setSelectedIndex(found.index);
+                setFocus('graph');
+              }
             }
             break;
         }
@@ -304,8 +309,7 @@ export default function useKeyboard({
           if (selectedNode) {
             setQueue(q => [...q, {
               type: 'ref',
-              path: [...path],
-              index: selectedIndex,
+              nodeId: selectedNode.id,
               text: selectedNode.text,
               checked: selectedNode.checked || false,
             }]);

--- a/tests/issue-12.spec.js
+++ b/tests/issue-12.spec.js
@@ -194,3 +194,46 @@ test('issue 12: editing queue ref item updates the tree node', async ({ page }) 
   const firstNode = page.locator('.node-box').first();
   await expect(firstNode).toContainText('Edited from queue');
 });
+
+test('issue 12: queue ref survives tree reordering (ID-based refs)', async ({ page }) => {
+  await setupMocks(page);
+  await page.goto('http://localhost:5173');
+
+  await page.waitForSelector('.app', { timeout: 10000 });
+  await page.waitForSelector('.node-box', { timeout: 10000 });
+  await pause(500);
+
+  // Navigate into children (3 items: "Use arrow keys...", "Press Enter...", "Press Cmd+Down...")
+  await page.keyboard.press('ArrowRight');
+  await pause(800);
+
+  // Add the second child ("Press Enter to edit") to queue
+  await page.keyboard.press('ArrowDown');
+  await pause(200);
+  await page.keyboard.press('q');
+  await pause(300);
+
+  // Verify queue shows the correct item
+  const queueItem = page.locator('.queue-box').first();
+  await expect(queueItem).toContainText('Press Enter to edit');
+
+  // Now go back to the first child and check it off (moves it to end, shifting indices)
+  await page.keyboard.press('ArrowUp');
+  await pause(200);
+  await page.keyboard.press('c');
+  await pause(300);
+
+  // The queue item should STILL show "Press Enter to edit" (not the shifted node)
+  // because we use ID-based refs, not positional indices
+  await expect(queueItem).toContainText('Press Enter to edit');
+
+  // Navigate to queue and press 'q' to jump to the ref'd node in tree
+  await page.keyboard.press('ArrowUp');
+  await pause(300);
+  await page.keyboard.press('q');
+  await pause(300);
+
+  // The selected node should be "Press Enter to edit"
+  const selectedNode = page.locator('.node-box.selected');
+  await expect(selectedNode).toContainText('Press Enter to edit');
+});


### PR DESCRIPTION
Closes #12

Auto-generated fix by Claude Code agent.

## Issue
In fact, the things in the queue should be soft references to things in the tree. Actually, I want to be able to edit the same data directly from both the cue and the tree as well. Right now you can only edit it in the tree but not the queue

<img width="900" height="451" alt="Image" src="https://github.com/user-attachments/assets/03143ba1-8f3f-4243-8671-6631e5cc777f" />