### PR TITLE
feat: add deadline and priority metadata panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import { DeleteConfirmModal, ClearCheckedModal } from './components/ConfirmModal
 import ConflictModal from './components/ConflictModal';
 import HotkeyLegend from './components/HotkeyLegend';
 import QueueBar from './components/QueueBar';
+import DeadlineBadge from './components/DeadlineBadge';
+import MetadataPanel from './components/MetadataPanel';
 import useEjectAnimation from './hooks/useEjectAnimation';
 import useSlideAnimation from './hooks/useSlideAnimation';
 import useSvgLines from './hooks/useSvgLines';
@@ -25,6 +27,7 @@ import { loadUserTree, saveUserTree, loadUserQueue, saveUserQueue, saveBackup, d
 import { supabase } from './supabaseClient';
 import { marked } from 'marked';
 import './App.css';
+import './components/deadline.css';
 
 marked.setOptions({ breaks: true });
 
@@ -47,7 +50,9 @@ export default function App({ session }) {
   const [physics, setPhysics] = useState({ vx: 1.2, vy: -1.2, gravity: 0.4, spin: 0.04 });
   const [focus, setFocus] = useState('graph');
   const [conflict, setConflict] = useState(null); // { localTree, serverTree, serverVersion }
+  const [calendarOpen, setCalendarOpen] = useState(false);
   const editInputRef = useRef(null);
+  const selectedNodeRef = useRef(null);
   const queueEditRef = useRef(null);
   const fileInputRef = useRef(null);
   const loadedRef = useRef(false);
@@ -223,6 +228,28 @@ export default function App({ session }) {
     setTimeout(() => setToast(null), 5000);
   }, [conflict, userId]);
 
+  const setNodeDeadline = useCallback((dateStr) => {
+    if (!tree || !selectedNode) return;
+    const newTree = cloneTree(tree);
+    let nodes = newTree;
+    for (const idx of path) nodes = nodes[idx].children;
+    nodes[selectedIndex].deadline = dateStr;
+    setUndoStack(stack => [...stack, { tree: cloneTree(tree), path, selectedIndex }]);
+    setRedoStack([]);
+    setTree(newTree);
+  }, [tree, path, selectedIndex, selectedNode]);
+
+  const setNodePriority = useCallback((priority) => {
+    if (!tree || !selectedNode) return;
+    const newTree = cloneTree(tree);
+    let nodes = newTree;
+    for (const idx of path) nodes = nodes[idx].children;
+    nodes[selectedIndex].priority = priority;
+    setUndoStack(stack => [...stack, { tree: cloneTree(tree), path, selectedIndex }]);
+    setRedoStack([]);
+    setTree(newTree);
+  }, [tree, path, selectedIndex, selectedNode]);
+
   useKeyboard({
     tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen,
     getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, animatingRef, ejectQueueItem,
@@ -231,6 +258,7 @@ export default function App({ session }) {
     setFocus, setSelectedIndex, setPath, setMode, setBackupOpen,
     onSave: userId ? handleSave : undefined,
     conflict, onConflictKeepMine: handleConflictKeepMine, onConflictKeepTheirs: handleConflictKeepTheirs, onConflictKeepBoth: handleConflictKeepBoth,
+    calendarOpen, setCalendarOpen,
   });
 
   // Scroll selected item into view
@@ -547,6 +575,7 @@ export default function App({ session }) {
                 return (
                   <div
                     key={i}
+                    ref={isSelected ? selectedNodeRef : undefined}
                     className={`node-box ${isSelected && !isEditing ? 'selected' : ''} ${isEditing ? 'editing' : ''} ${node.checked ? 'checked' : ''}`}
                     onClick={() => handleNodeClick(i)}
                     onDoubleClick={() => {
@@ -587,6 +616,8 @@ export default function App({ session }) {
                       <span className="node-text"><Linkify text={node.text} /></span>
                     )}
                     <div className="node-meta">
+                      <DeadlineBadge deadline={node.deadline} />
+                      {node.priority && <span className={`priority-badge ${node.priority}`}>{node.priority}</span>}
                       {node.markdown && <span className="markdown-badge">MD</span>}
                       {node.checked && <span>&#10003;</span>}
                       {node.children.length > 0 && (
@@ -699,6 +730,14 @@ export default function App({ session }) {
           onKeepMine={handleConflictKeepMine}
           onKeepTheirs={handleConflictKeepTheirs}
           onKeepBoth={handleConflictKeepBoth}
+        />
+      )}
+      {calendarOpen && selectedNode && (
+        <MetadataPanel
+          node={selectedNode}
+          onSetDeadline={(dateStr) => setNodeDeadline(dateStr)}
+          onSetPriority={(priority) => setNodePriority(priority)}
+          onClose={() => setCalendarOpen(false)}
         />
       )}
       <HotkeyLegend mode={mode} />

--- a/src/components/DeadlineBadge.jsx
+++ b/src/components/DeadlineBadge.jsx
@@ -1,0 +1,26 @@
+export default function DeadlineBadge({ deadline }) {
+  if (!deadline) return null;
+
+  const date = new Date(deadline);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const deadlineDate = new Date(date);
+  deadlineDate.setHours(0, 0, 0, 0);
+
+  const diffDays = Math.round((deadlineDate - today) / (1000 * 60 * 60 * 24));
+
+  let className = 'deadline-badge';
+  if (diffDays < 0) className += ' overdue';
+  else if (diffDays === 0) className += ' today';
+  else if (diffDays <= 2) className += ' soon';
+
+  const month = date.toLocaleString('en', { month: 'short' });
+  const day = date.getDate();
+
+  let label = `${month} ${day}`;
+  if (diffDays === 0) label = 'Today';
+  else if (diffDays === 1) label = 'Tomorrow';
+  else if (diffDays === -1) label = 'Yesterday';
+
+  return <span className={className}>{label}</span>;
+}

--- a/src/components/HotkeyLegend.jsx
+++ b/src/components/HotkeyLegend.jsx
@@ -67,6 +67,10 @@ export default function HotkeyLegend({ mode }) {
             <span className="legend-desc">Add to queue</span>
           </div>
           <div className="legend-row">
+            <kbd>d</kbd>
+            <span className="legend-desc">Deadline / metadata</span>
+          </div>
+          <div className="legend-row">
             <span className="legend-keys arrow-keys">
               <kbd>&#8984;</kbd>
               <span className="legend-plus">+</span>

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from 'react';
+
+const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const PRIORITIES = [null, 'low', 'medium', 'high', 'urgent'];
+const PRIORITY_LABELS = { low: 'Low', medium: 'Medium', high: 'High', urgent: 'Urgent' };
+
+function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function getFirstDayOfWeek(year, month) {
+  return new Date(year, month, 1).getDay();
+}
+
+export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onClose }) {
+  const today = new Date();
+  const initial = node?.deadline ? new Date(node.deadline) : today;
+
+  const [activeField, setActiveField] = useState('deadline'); // 'deadline' | 'priority'
+  const [viewYear, setViewYear] = useState(initial.getFullYear());
+  const [viewMonth, setViewMonth] = useState(initial.getMonth());
+  const [cursorDay, setCursorDay] = useState(initial.getDate());
+  const [priorityIndex, setPriorityIndex] = useState(
+    node?.priority ? PRIORITIES.indexOf(node.priority) : 0
+  );
+
+  const daysInMonth = getDaysInMonth(viewYear, viewMonth);
+  const firstDay = getFirstDayOfWeek(viewYear, viewMonth);
+  const monthName = new Date(viewYear, viewMonth).toLocaleString('en', { month: 'long', year: 'numeric' });
+
+  useEffect(() => {
+    function handleKey(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === 'Tab') {
+        setActiveField(f => f === 'deadline' ? 'priority' : 'deadline');
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (activeField === 'deadline') {
+        switch (e.key) {
+          case 'ArrowRight':
+            setCursorDay(d => {
+              if (d >= daysInMonth) {
+                if (viewMonth === 11) { setViewYear(y => y + 1); setViewMonth(0); }
+                else setViewMonth(m => m + 1);
+                return 1;
+              }
+              return d + 1;
+            });
+            break;
+          case 'ArrowLeft':
+            setCursorDay(d => {
+              if (d <= 1) {
+                if (viewMonth === 0) { setViewYear(y => y - 1); setViewMonth(11); }
+                else setViewMonth(m => m - 1);
+                const prevDays = getDaysInMonth(
+                  viewMonth === 0 ? viewYear - 1 : viewYear,
+                  viewMonth === 0 ? 11 : viewMonth - 1
+                );
+                return prevDays;
+              }
+              return d - 1;
+            });
+            break;
+          case 'ArrowDown':
+            setCursorDay(d => {
+              const next = d + 7;
+              if (next > daysInMonth) {
+                if (viewMonth === 11) { setViewYear(y => y + 1); setViewMonth(0); }
+                else setViewMonth(m => m + 1);
+                return next - daysInMonth;
+              }
+              return next;
+            });
+            break;
+          case 'ArrowUp':
+            setCursorDay(d => {
+              const prev = d - 7;
+              if (prev < 1) {
+                const prevMonth = viewMonth === 0 ? 11 : viewMonth - 1;
+                const prevYear = viewMonth === 0 ? viewYear - 1 : viewYear;
+                if (viewMonth === 0) { setViewYear(y => y - 1); setViewMonth(11); }
+                else setViewMonth(m => m - 1);
+                return getDaysInMonth(prevYear, prevMonth) + prev;
+              }
+              return prev;
+            });
+            break;
+          case 'Enter':
+            onSetDeadline(new Date(viewYear, viewMonth, cursorDay).toISOString().slice(0, 10));
+            break;
+          case 'Backspace':
+          case 'Delete':
+            onSetDeadline(null);
+            break;
+        }
+      } else if (activeField === 'priority') {
+        switch (e.key) {
+          case 'ArrowUp':
+            setPriorityIndex(i => Math.max(0, i - 1));
+            break;
+          case 'ArrowDown':
+            setPriorityIndex(i => Math.min(PRIORITIES.length - 1, i + 1));
+            break;
+          case 'Enter':
+            onSetPriority(PRIORITIES[priorityIndex]);
+            break;
+          case 'Backspace':
+          case 'Delete':
+            onSetPriority(null);
+            setPriorityIndex(0);
+            break;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKey, true);
+    return () => window.removeEventListener('keydown', handleKey, true);
+  }, [viewYear, viewMonth, cursorDay, daysInMonth, activeField, priorityIndex, onSetDeadline, onSetPriority, onClose]);
+
+  // Build calendar grid
+  const cells = [];
+  for (let i = 0; i < firstDay; i++) {
+    cells.push(<div key={`empty-${i}`} className="cal-cell empty" />);
+  }
+
+  const todayStr = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
+  const deadlineStr = node?.deadline ? (() => {
+    const d = new Date(node.deadline);
+    return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+  })() : null;
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dayStr = `${viewYear}-${viewMonth}-${d}`;
+    const isCursor = d === cursorDay && activeField === 'deadline';
+    const isToday = dayStr === todayStr;
+    const isDeadline = dayStr === deadlineStr;
+
+    let cls = 'cal-cell';
+    if (isCursor) cls += ' cursor';
+    if (isToday) cls += ' today';
+    if (isDeadline) cls += ' deadline';
+
+    cells.push(
+      <div key={d} className={cls} onClick={() => onSetDeadline(new Date(viewYear, viewMonth, d).toISOString().slice(0, 10))}>
+        {d}
+      </div>
+    );
+  }
+
+  return (
+    <div className="metadata-panel">
+      <div className="meta-panel-header">
+        <span className="meta-panel-title">Node Metadata</span>
+        <span className="meta-panel-hint"><kbd>Tab</kbd> switch field &nbsp; <kbd>Esc</kbd> close</span>
+      </div>
+
+      <div className="meta-panel-node-preview">
+        {node?.text || 'No node selected'}
+      </div>
+
+      <div className={`meta-field ${activeField === 'deadline' ? 'active' : ''}`}>
+        <div className="meta-field-label">
+          Deadline
+          {node?.deadline && <span className="meta-field-value">{node.deadline}</span>}
+        </div>
+        <div className="cal-header-panel">
+          <span className="cal-month">{monthName}</span>
+        </div>
+        <div className="cal-weekdays">
+          {DAYS.map(d => <div key={d} className="cal-weekday">{d}</div>)}
+        </div>
+        <div className="cal-grid">
+          {cells}
+        </div>
+        <div className="meta-field-actions">
+          <kbd>Enter</kbd> set &nbsp; <kbd>Del</kbd> clear
+        </div>
+      </div>
+
+      <div className={`meta-field ${activeField === 'priority' ? 'active' : ''}`}>
+        <div className="meta-field-label">
+          Priority
+          {node?.priority && <span className={`priority-value ${node.priority}`}>{PRIORITY_LABELS[node.priority]}</span>}
+        </div>
+        <div className="priority-list">
+          {PRIORITIES.map((p, i) => (
+            <div
+              key={i}
+              className={`priority-option ${i === priorityIndex && activeField === 'priority' ? 'cursor' : ''} ${p === node?.priority ? 'current' : ''}`}
+              onClick={() => onSetPriority(p)}
+            >
+              <span className={`priority-dot ${p || 'none'}`} />
+              <span>{p ? PRIORITY_LABELS[p] : 'None'}</span>
+            </div>
+          ))}
+        </div>
+        <div className="meta-field-actions">
+          <kbd>&uarr;</kbd><kbd>&darr;</kbd> select &nbsp; <kbd>Enter</kbd> set
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/deadline.css
+++ b/src/components/deadline.css
@@ -1,0 +1,284 @@
+/* ===== Deadline Badge (on nodes) ===== */
+.deadline-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 3px;
+  background: #0f3460;
+  color: #7bb8e8;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+.deadline-badge.today {
+  background: #e94560;
+  color: #fff;
+}
+
+.deadline-badge.soon {
+  background: #c4783e;
+  color: #fff;
+}
+
+.deadline-badge.overdue {
+  background: #8b2035;
+  color: #ff8a9e;
+  animation: overdue-pulse 2s ease-in-out infinite;
+}
+
+@keyframes overdue-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* Priority badge on nodes */
+.priority-badge {
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.priority-badge.low { background: #1a4a3a; color: #4ade80; }
+.priority-badge.medium { background: #4a3a1a; color: #fbbf24; }
+.priority-badge.high { background: #4a2a1a; color: #fb923c; }
+.priority-badge.urgent { background: #4a1a2a; color: #f87171; }
+
+/* ===== Shared Calendar Styles ===== */
+.cal-header-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.cal-month {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.cal-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 4px;
+}
+
+.cal-weekday {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: #666;
+  padding: 2px 0;
+}
+
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.cal-cell {
+  text-align: center;
+  font-size: 12px;
+  padding: 5px 2px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #aaa;
+  transition: background 0.1s, color 0.1s;
+}
+
+.cal-cell:hover:not(.empty) {
+  background: #1a2a4e;
+}
+
+.cal-cell.empty {
+  cursor: default;
+}
+
+.cal-cell.cursor {
+  background: #e94560;
+  color: #fff;
+  font-weight: 700;
+  box-shadow: 0 0 8px rgba(233, 69, 96, 0.4);
+}
+
+.cal-cell.today:not(.cursor) {
+  color: #e94560;
+  font-weight: 700;
+}
+
+.cal-cell.deadline:not(.cursor) {
+  background: #0f3460;
+  color: #7bb8e8;
+  font-weight: 600;
+}
+
+/* ===== Metadata Panel ===== */
+.metadata-panel {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 320px;
+  background: #16213e;
+  border-left: 1px solid #0f3460;
+  padding: 20px;
+  z-index: 100;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  animation: panel-slide 0.2s ease-out;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes panel-slide {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+.meta-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta-panel-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e94560;
+}
+
+.meta-panel-hint {
+  font-size: 10px;
+  color: #666;
+}
+
+.meta-panel-hint kbd {
+  font-size: 9px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+}
+
+.meta-panel-node-preview {
+  font-size: 13px;
+  color: #aaa;
+  padding: 8px 10px;
+  background: #1a1a2e;
+  border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: 1px solid #0f3460;
+}
+
+.meta-field {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #0f3460;
+  background: #1a1a2e;
+  transition: border-color 0.2s;
+}
+
+.meta-field.active {
+  border-color: #e94560;
+  box-shadow: 0 0 8px rgba(233, 69, 96, 0.15);
+}
+
+.meta-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #888;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.meta-field-value {
+  font-size: 12px;
+  color: #7bb8e8;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.meta-field-actions {
+  margin-top: 8px;
+  font-size: 10px;
+  color: #555;
+  text-align: right;
+}
+
+.meta-field-actions kbd {
+  font-size: 9px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+}
+
+/* Priority list in metadata panel */
+.priority-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.priority-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #aaa;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.priority-option:hover {
+  background: #1a2a4e;
+}
+
+.priority-option.cursor {
+  background: #0f3460;
+  color: #e0e0e0;
+  box-shadow: inset 2px 0 0 #e94560;
+}
+
+.priority-option.current {
+  color: #e0e0e0;
+  font-weight: 600;
+}
+
+.priority-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.priority-dot.none { background: #444; }
+.priority-dot.low { background: #4ade80; }
+.priority-dot.medium { background: #fbbf24; }
+.priority-dot.high { background: #fb923c; }
+.priority-dot.urgent { background: #f87171; }
+
+.priority-value {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.priority-value.low { background: #1a4a3a; color: #4ade80; }
+.priority-value.medium { background: #4a3a1a; color: #fbbf24; }
+.priority-value.high { background: #4a2a1a; color: #fb923c; }
+.priority-value.urgent { background: #4a1a2a; color: #f87171; }

--- a/src/hooks/useKeyboard.js
+++ b/src/hooks/useKeyboard.js
@@ -25,6 +25,7 @@ export default function useKeyboard({
   setFocus, setSelectedIndex, setPath, setMode,
   onSave, setBackupOpen,
   conflict, onConflictKeepMine, onConflictKeepTheirs, onConflictKeepBoth,
+  calendarOpen, setCalendarOpen,
 }) {
   useEffect(() => {
     function handleKeyDown(e) {
@@ -43,6 +44,9 @@ export default function useKeyboard({
       }
 
       if (mode === 'edit') return;
+
+      // Metadata panel is open — let the component handle keys
+      if (calendarOpen) return;
 
       // Conflict modal — 1/2/3 to resolve
       if (conflict) {
@@ -335,10 +339,16 @@ export default function useKeyboard({
           e.preventDefault();
           setBackupOpen(true);
           break;
+        case 'd':
+          e.preventDefault();
+          if (selectedNode) {
+            setCalendarOpen(true);
+          }
+          break;
       }
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen, getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, focus, queue, queueIndex, animatingRef, ejectQueueItem, setToast, setSettingsOpen, setDeleteConfirm, setClearCheckedConfirm, setQueue, setQueueIndex, setFocus, setSelectedIndex, setPath, setMode, onSave, setBackupOpen, conflict, onConflictKeepMine, onConflictKeepTheirs, onConflictKeepBoth]);
+  }, [tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen, getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, focus, queue, queueIndex, animatingRef, ejectQueueItem, setToast, setSettingsOpen, setDeleteConfirm, setClearCheckedConfirm, setQueue, setQueueIndex, setFocus, setSelectedIndex, setPath, setMode, onSave, setBackupOpen, conflict, onConflictKeepMine, onConflictKeepTheirs, onConflictKeepBoth, calendarOpen, setCalendarOpen]);
 }


### PR DESCRIPTION
## Summary

- **Side panel (D key)**: Opens a metadata panel on the right side for the selected node, with a keyboard-navigable calendar to set deadlines and a priority picker (None/Low/Medium/High/Urgent)
- **Deadline badges**: Nodes with deadlines show color-coded badges — overdue (red with pulse animation), today (pink), soon/within 2 days (orange), future (blue)
- **Priority badges**: Nodes with priorities show colored badges matching urgency level
- **Keyboard controls**: Arrow keys navigate calendar, Tab switches between deadline/priority fields, Enter confirms, Delete/Backspace clears, Escape closes panel
- **Data persistence**: `deadline` (ISO date string) and `priority` fields are stored directly on tree nodes in the existing JSON blob — no schema migration needed

## What's NOT included (Phase 2)

- Google Calendar sync is not implemented — this PR is UI + data persistence only
- No `InlineCalendar` (Design A was dropped in favor of the side panel Design B)

## Test plan

- [ ] Press `D` on a selected node — metadata panel slides in from the right
- [ ] Use arrow keys to navigate the calendar, press Enter to set a deadline
- [ ] Press Tab to switch to priority field, arrow up/down to select, Enter to confirm
- [ ] Verify deadline badge appears on the node with correct color coding
- [ ] Press `D` again, then Delete to clear the deadline
- [ ] Press Escape to close the panel
- [ ] Verify undo (z) reverts deadline/priority changes
- [ ] Verify data persists after page reload (auto-save)
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)