### PR TITLE
feat: time-of-day and duration pickers for deadlines

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -250,6 +250,28 @@ export default function App({ session }) {
     setTree(newTree);
   }, [tree, path, selectedIndex, selectedNode]);
 
+  const setNodeTime = useCallback((time) => {
+    if (!tree || !selectedNode) return;
+    const newTree = cloneTree(tree);
+    let nodes = newTree;
+    for (const idx of path) nodes = nodes[idx].children;
+    nodes[selectedIndex].deadlineTime = time;
+    setUndoStack(stack => [...stack, { tree: cloneTree(tree), path, selectedIndex }]);
+    setRedoStack([]);
+    setTree(newTree);
+  }, [tree, path, selectedIndex, selectedNode]);
+
+  const setNodeDuration = useCallback((duration) => {
+    if (!tree || !selectedNode) return;
+    const newTree = cloneTree(tree);
+    let nodes = newTree;
+    for (const idx of path) nodes = nodes[idx].children;
+    nodes[selectedIndex].deadlineDuration = duration;
+    setUndoStack(stack => [...stack, { tree: cloneTree(tree), path, selectedIndex }]);
+    setRedoStack([]);
+    setTree(newTree);
+  }, [tree, path, selectedIndex, selectedNode]);
+
   useKeyboard({
     tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen,
     getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, animatingRef, ejectQueueItem,
@@ -616,7 +638,7 @@ export default function App({ session }) {
                       <span className="node-text"><Linkify text={node.text} /></span>
                     )}
                     <div className="node-meta">
-                      <DeadlineBadge deadline={node.deadline} />
+                      <DeadlineBadge deadline={node.deadline} deadlineTime={node.deadlineTime} deadlineDuration={node.deadlineDuration} />
                       {node.priority && <span className={`priority-badge ${node.priority}`}>{node.priority}</span>}
                       {node.markdown && <span className="markdown-badge">MD</span>}
                       {node.checked && <span>&#10003;</span>}
@@ -737,6 +759,8 @@ export default function App({ session }) {
           node={selectedNode}
           onSetDeadline={(dateStr) => setNodeDeadline(dateStr)}
           onSetPriority={(priority) => setNodePriority(priority)}
+          onSetTime={(time) => setNodeTime(time)}
+          onSetDuration={(duration) => setNodeDuration(duration)}
           onClose={() => setCalendarOpen(false)}
         />
       )}

--- a/src/components/DeadlineBadge.jsx
+++ b/src/components/DeadlineBadge.jsx
@@ -1,4 +1,4 @@
-export default function DeadlineBadge({ deadline }) {
+export default function DeadlineBadge({ deadline, deadlineTime, deadlineDuration }) {
   if (!deadline) return null;
 
   const date = new Date(deadline);
@@ -21,6 +21,25 @@ export default function DeadlineBadge({ deadline }) {
   if (diffDays === 0) label = 'Today';
   else if (diffDays === 1) label = 'Tomorrow';
   else if (diffDays === -1) label = 'Yesterday';
+
+  // Append time if set
+  if (deadlineTime) {
+    const [h, m] = deadlineTime.split(':').map(Number);
+    const period = h >= 12 ? 'PM' : 'AM';
+    const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+    label += ` ${h12}:${String(m).padStart(2, '0')} ${period}`;
+  }
+
+  // Append duration if set
+  if (deadlineDuration) {
+    if (deadlineDuration < 60) {
+      label += ` (${deadlineDuration}m)`;
+    } else {
+      const dh = Math.floor(deadlineDuration / 60);
+      const dm = deadlineDuration % 60;
+      label += dm === 0 ? ` (${dh}h)` : ` (${dh}h${dm}m)`;
+    }
+  }
 
   return <span className={className}>{label}</span>;
 }

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -4,6 +4,39 @@ const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 const PRIORITIES = [null, 'low', 'medium', 'high', 'urgent'];
 const PRIORITY_LABELS = { low: 'Low', medium: 'Medium', high: 'High', urgent: 'Urgent' };
 
+// 15-minute time slots: 0..95 => "00:00".."23:45"
+const TIME_SLOTS = Array.from({ length: 96 }, (_, i) => {
+  const h = Math.floor(i / 4);
+  const m = (i % 4) * 15;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+});
+
+// Duration options in minutes: 15, 30, 45, ... 240 (4h)
+const DURATION_OPTIONS = Array.from({ length: 16 }, (_, i) => (i + 1) * 15);
+
+function formatTime12h(time24) {
+  const [h, m] = time24.split(':').map(Number);
+  const period = h >= 12 ? 'PM' : 'AM';
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${h12}:${String(m).padStart(2, '0')} ${period}`;
+}
+
+function formatDuration(minutes) {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m === 0 ? `${h}h` : `${h}h${m}m`;
+}
+
+function timeToIndex(time24) {
+  const [h, m] = time24.split(':').map(Number);
+  return h * 4 + m / 15;
+}
+
+function durationToIndex(minutes) {
+  return DURATION_OPTIONS.indexOf(minutes);
+}
+
 function getDaysInMonth(year, month) {
   return new Date(year, month + 1, 0).getDate();
 }
@@ -12,14 +45,22 @@ function getFirstDayOfWeek(year, month) {
   return new Date(year, month, 1).getDay();
 }
 
-export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onClose }) {
+const FIELDS = ['deadline', 'time', 'duration', 'priority'];
+
+export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onSetTime, onSetDuration, onClose }) {
   const today = new Date();
   const initial = node?.deadline ? new Date(node.deadline) : today;
 
-  const [activeField, setActiveField] = useState('deadline'); // 'deadline' | 'priority'
+  const [activeField, setActiveField] = useState('deadline');
   const [viewYear, setViewYear] = useState(initial.getFullYear());
   const [viewMonth, setViewMonth] = useState(initial.getMonth());
   const [cursorDay, setCursorDay] = useState(initial.getDate());
+  const [timeIndex, setTimeIndex] = useState(
+    node?.deadlineTime ? timeToIndex(node.deadlineTime) : 36 // default 9:00 AM
+  );
+  const [durationIndex, setDurationIndex] = useState(
+    node?.deadlineDuration ? Math.max(0, durationToIndex(node.deadlineDuration)) : 1 // default 30min
+  );
   const [priorityIndex, setPriorityIndex] = useState(
     node?.priority ? PRIORITIES.indexOf(node.priority) : 0
   );
@@ -34,7 +75,10 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
       e.stopPropagation();
 
       if (e.key === 'Tab') {
-        setActiveField(f => f === 'deadline' ? 'priority' : 'deadline');
+        setActiveField(f => {
+          const idx = FIELDS.indexOf(f);
+          return FIELDS[(idx + 1) % FIELDS.length];
+        });
         return;
       }
 
@@ -101,6 +145,44 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
             onSetDeadline(null);
             break;
         }
+      } else if (activeField === 'time') {
+        switch (e.key) {
+          case 'ArrowUp':
+            setTimeIndex(i => (i - 1 + 96) % 96);
+            break;
+          case 'ArrowDown':
+            setTimeIndex(i => (i + 1) % 96);
+            break;
+          case 'ArrowLeft':
+            setTimeIndex(i => (i - 4 + 96) % 96); // -1 hour
+            break;
+          case 'ArrowRight':
+            setTimeIndex(i => (i + 4) % 96); // +1 hour
+            break;
+          case 'Enter':
+            onSetTime(TIME_SLOTS[timeIndex]);
+            break;
+          case 'Backspace':
+          case 'Delete':
+            onSetTime(null);
+            break;
+        }
+      } else if (activeField === 'duration') {
+        switch (e.key) {
+          case 'ArrowUp':
+            setDurationIndex(i => Math.max(0, i - 1));
+            break;
+          case 'ArrowDown':
+            setDurationIndex(i => Math.min(DURATION_OPTIONS.length - 1, i + 1));
+            break;
+          case 'Enter':
+            onSetDuration(DURATION_OPTIONS[durationIndex]);
+            break;
+          case 'Backspace':
+          case 'Delete':
+            onSetDuration(null);
+            break;
+        }
       } else if (activeField === 'priority') {
         switch (e.key) {
           case 'ArrowUp':
@@ -123,7 +205,7 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
 
     window.addEventListener('keydown', handleKey, true);
     return () => window.removeEventListener('keydown', handleKey, true);
-  }, [viewYear, viewMonth, cursorDay, daysInMonth, activeField, priorityIndex, onSetDeadline, onSetPriority, onClose]);
+  }, [viewYear, viewMonth, cursorDay, daysInMonth, activeField, priorityIndex, timeIndex, durationIndex, onSetDeadline, onSetPriority, onSetTime, onSetDuration, onClose]);
 
   // Build calendar grid
   const cells = [];
@@ -155,6 +237,22 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
     );
   }
 
+  // Visible time slots around cursor (show 5 slots centered on cursor)
+  const visibleTimeSlots = [];
+  for (let offset = -2; offset <= 2; offset++) {
+    const idx = (timeIndex + offset + 96) % 96;
+    visibleTimeSlots.push({ index: idx, time: TIME_SLOTS[idx], isCursor: offset === 0 });
+  }
+
+  // Visible duration options around cursor (show 5)
+  const visibleDurationSlots = [];
+  for (let offset = -2; offset <= 2; offset++) {
+    const idx = durationIndex + offset;
+    if (idx >= 0 && idx < DURATION_OPTIONS.length) {
+      visibleDurationSlots.push({ index: idx, value: DURATION_OPTIONS[idx], isCursor: offset === 0 });
+    }
+  }
+
   return (
     <div className="metadata-panel">
       <div className="meta-panel-header">
@@ -166,6 +264,7 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
         {node?.text || 'No node selected'}
       </div>
 
+      {/* Calendar / Date */}
       <div className={`meta-field ${activeField === 'deadline' ? 'active' : ''}`}>
         <div className="meta-field-label">
           Deadline
@@ -185,6 +284,51 @@ export default function MetadataPanel({ node, onSetDeadline, onSetPriority, onCl
         </div>
       </div>
 
+      {/* Time picker */}
+      <div className={`meta-field ${activeField === 'time' ? 'active' : ''}`}>
+        <div className="meta-field-label">
+          Time
+          {node?.deadlineTime && <span className="meta-field-value">{formatTime12h(node.deadlineTime)}</span>}
+        </div>
+        <div className="time-picker">
+          {visibleTimeSlots.map(({ index, time, isCursor }) => (
+            <div
+              key={index}
+              className={`time-option ${isCursor && activeField === 'time' ? 'cursor' : ''} ${time === node?.deadlineTime ? 'current' : ''}`}
+              onClick={() => onSetTime(time)}
+            >
+              {formatTime12h(time)}
+            </div>
+          ))}
+        </div>
+        <div className="meta-field-actions">
+          <kbd>&uarr;</kbd><kbd>&darr;</kbd> 15min &nbsp; <kbd>&larr;</kbd><kbd>&rarr;</kbd> 1hr &nbsp; <kbd>Enter</kbd> set
+        </div>
+      </div>
+
+      {/* Duration picker */}
+      <div className={`meta-field ${activeField === 'duration' ? 'active' : ''}`}>
+        <div className="meta-field-label">
+          Duration
+          {node?.deadlineDuration && <span className="meta-field-value">{formatDuration(node.deadlineDuration)}</span>}
+        </div>
+        <div className="time-picker">
+          {visibleDurationSlots.map(({ index, value, isCursor }) => (
+            <div
+              key={index}
+              className={`time-option ${isCursor && activeField === 'duration' ? 'cursor' : ''} ${value === node?.deadlineDuration ? 'current' : ''}`}
+              onClick={() => onSetDuration(value)}
+            >
+              {formatDuration(value)}
+            </div>
+          ))}
+        </div>
+        <div className="meta-field-actions">
+          <kbd>&uarr;</kbd><kbd>&darr;</kbd> 15min &nbsp; <kbd>Enter</kbd> set
+        </div>
+      </div>
+
+      {/* Priority */}
       <div className={`meta-field ${activeField === 'priority' ? 'active' : ''}`}>
         <div className="meta-field-label">
           Priority

--- a/src/components/deadline.css
+++ b/src/components/deadline.css
@@ -282,3 +282,38 @@
 .priority-value.medium { background: #4a3a1a; color: #fbbf24; }
 .priority-value.high { background: #4a2a1a; color: #fb923c; }
 .priority-value.urgent { background: #4a1a2a; color: #f87171; }
+
+/* ===== Time / Duration Picker ===== */
+.time-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.time-option {
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #666;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.1s, color 0.1s;
+  font-variant-numeric: tabular-nums;
+}
+
+.time-option:hover {
+  background: #1a2a4e;
+  color: #aaa;
+}
+
+.time-option.cursor {
+  background: #0f3460;
+  color: #e0e0e0;
+  font-weight: 600;
+  box-shadow: inset 2px 0 0 #e94560;
+}
+
+.time-option.current {
+  color: #7bb8e8;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Adds a **time-of-day picker** (15-min increments, 12h display, 24h storage) to MetadataPanel after the calendar date picker
- Adds a **duration picker** (15min to 4h in 15-min steps) after the time picker
- Updates Tab order to: Calendar -> Time -> Duration -> Priority -> wrap
- DeadlineBadge now shows time and duration when set (e.g., "Mar 15 2:30 PM (30m)")
- All keyboard-driven: up/down for 15min steps, left/right for 1hr jumps on time picker
- Data stored as `deadlineTime: "14:30"` and `deadlineDuration: 30` on tree nodes

## Test plan
- [ ] Open metadata panel (press `d` on a node)
- [ ] Tab through all 4 fields: Calendar, Time, Duration, Priority
- [ ] Use arrow keys to navigate time (up/down = 15min, left/right = 1hr)
- [ ] Use arrow keys to navigate duration (up/down = 15min)
- [ ] Press Enter to set time/duration, verify badge updates
- [ ] Press Delete to clear time/duration
- [ ] Verify existing deadline and priority functionality unchanged
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)