### PR TITLE
fix: Option for shift enter for new line instead of enter (which brings back to visual mode after edit)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -808,6 +808,23 @@ export default function App({ session }) {
                               return;
                             }
                           }
+                          if (e.key === 'Enter' && settings.enterNewline) {
+                            if (e.shiftKey) {
+                              e.preventDefault();
+                              commitEdit(e.target.value);
+                              e.stopPropagation();
+                              return;
+                            }
+                            // Enter without shift = newline (default textarea behavior)
+                          } else if (e.key === 'Enter' && !settings.enterNewline) {
+                            if (!e.shiftKey) {
+                              e.preventDefault();
+                              commitEdit(e.target.value);
+                              e.stopPropagation();
+                              return;
+                            }
+                            // Shift+Enter = newline (default textarea behavior)
+                          }
                           if (e.key === 'Escape') {
                             e.preventDefault();
                             commitEdit(e.target.value);
@@ -1007,7 +1024,7 @@ export default function App({ session }) {
           } : null}
         />
       )}
-      {legendVisible && <HotkeyLegend mode={mode} focus={focus} keybindingScheme={settings.keybindingScheme} />}
+      {legendVisible && <HotkeyLegend mode={mode} focus={focus} keybindingScheme={settings.keybindingScheme} enterNewline={settings.enterNewline} />}
     </div>
   );
 }

--- a/src/components/HotkeyLegend.css
+++ b/src/components/HotkeyLegend.css
@@ -3,6 +3,7 @@
   position: fixed;
   bottom: 16px;
   left: 16px;
+  min-width: 260px;
   background: var(--bg-panel);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
@@ -26,6 +27,27 @@
 
 .hotkey-legend:hover {
   opacity: 1;
+}
+
+.legend-category {
+  grid-column: 1 / -1;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.legend-category:first-child {
+  margin-top: 0;
+}
+
+.legend-divider {
+  grid-column: 1 / -1;
+  height: 1px;
+  background: var(--border-secondary);
+  margin-bottom: 2px;
 }
 
 .legend-row {

--- a/src/components/HotkeyLegend.jsx
+++ b/src/components/HotkeyLegend.jsx
@@ -1,16 +1,21 @@
 import { getNavLabels } from '../keybindings';
 import './HotkeyLegend.css';
 
-export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
+export default function HotkeyLegend({ mode, focus, keybindingScheme, enterNewline }) {
   const isQueue = focus === 'queue';
   const nav = getNavLabels(keybindingScheme || 'arrows');
   const isVim = keybindingScheme === 'vim';
+
+  const exitKey = enterNewline ? 'Shift+Enter' : 'Enter';
+  const newlineKey = enterNewline ? 'Enter' : 'Shift+Enter';
 
   return (
     <div className="hotkey-legend">
       {mode === 'visual' ? (
         isQueue ? (
           <>
+            <div className="legend-category">Navigation</div>
+            <div className="legend-divider" />
             <div className="legend-row">
               <span className="legend-keys arrow-keys">
                 <kbd>{nav.leftSymbol}</kbd>
@@ -18,6 +23,13 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
               </span>
               <span className="legend-desc">Navigate queue</span>
             </div>
+            <div className="legend-row">
+              <kbd>{nav.downSymbol}</kbd>
+              <span className="legend-desc">Back to tree</span>
+            </div>
+
+            <div className="legend-category">Queue Actions</div>
+            <div className="legend-divider" />
             <div className="legend-row">
               <span className="legend-keys arrow-keys">
                 <kbd>&#8679;</kbd>
@@ -37,10 +49,6 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
               <span className="legend-desc">Insert temp card</span>
             </div>
             <div className="legend-row">
-              <kbd>{nav.downSymbol}</kbd>
-              <span className="legend-desc">Back to tree</span>
-            </div>
-            <div className="legend-row">
               <kbd>Enter</kbd>
               <span className="legend-desc">Edit item</span>
             </div>
@@ -56,6 +64,9 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
               <kbd>q</kbd>
               <span className="legend-desc">Jump to node</span>
             </div>
+
+            <div className="legend-category">Other</div>
+            <div className="legend-divider" />
             <div className="legend-row">
               <kbd>d</kbd>
               <span className="legend-desc">Deadline / metadata</span>
@@ -80,6 +91,8 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
           </>
         ) : (
           <>
+            <div className="legend-category">Navigation</div>
+            <div className="legend-divider" />
             <div className="legend-row">
               <span className="legend-keys arrow-keys">
                 <kbd>{nav.upSymbol}</kbd>
@@ -98,6 +111,13 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
               </span>
               <span className="legend-desc">Swap node</span>
             </div>
+
+            <div className="legend-category">Editing</div>
+            <div className="legend-divider" />
+            <div className="legend-row">
+              <kbd>Enter</kbd>
+              <span className="legend-desc">Edit selected</span>
+            </div>
             <div className="legend-row">
               <span className="legend-keys arrow-keys">
                 <kbd>&#8984;</kbd>
@@ -108,10 +128,6 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
                 <kbd>{nav.rightSymbol}</kbd>
               </span>
               <span className="legend-desc">Insert node</span>
-            </div>
-            <div className="legend-row">
-              <kbd>Enter</kbd>
-              <span className="legend-desc">Edit selected</span>
             </div>
             <div className="legend-row">
               <kbd>c</kbd>
@@ -133,10 +149,9 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
               </span>
               <span className="legend-desc">Redo</span>
             </div>
-            <div className="legend-row">
-              <kbd>m</kbd>
-              <span className="legend-desc">Toggle markdown</span>
-            </div>
+
+            <div className="legend-category">Queue & Metadata</div>
+            <div className="legend-divider" />
             <div className="legend-row">
               <kbd>q</kbd>
               <span className="legend-desc">Add to queue</span>
@@ -148,6 +163,13 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
             <div className="legend-row">
               <kbd>f</kbd>
               <span className="legend-desc">Calendar feed</span>
+            </div>
+
+            <div className="legend-category">Other</div>
+            <div className="legend-divider" />
+            <div className="legend-row">
+              <kbd>m</kbd>
+              <span className="legend-desc">Toggle markdown</span>
             </div>
             <div className="legend-row">
               <span className="legend-keys arrow-keys">
@@ -178,12 +200,18 @@ export default function HotkeyLegend({ mode, focus, keybindingScheme }) {
         )
       ) : (
         <>
+          <div className="legend-category">Edit Mode</div>
+          <div className="legend-divider" />
           <div className="legend-row">
             <kbd>Esc</kbd>
-            <span className="legend-desc">Confirm &amp; exit</span>
+            <span className="legend-desc">Confirm & exit</span>
           </div>
           <div className="legend-row">
-            <kbd>Enter</kbd>
+            <kbd>{exitKey}</kbd>
+            <span className="legend-desc">Confirm & exit</span>
+          </div>
+          <div className="legend-row">
+            <kbd>{newlineKey}</kbd>
             <span className="legend-desc">New line</span>
           </div>
         </>

--- a/src/components/WebSettingsPanel.css
+++ b/src/components/WebSettingsPanel.css
@@ -389,3 +389,49 @@
   background: var(--accent-gradient-hover) !important;
   box-shadow: 0 4px 12px var(--accent-glow-strong) !important;
 }
+
+/* ===== Enter Behavior Toggle ===== */
+.enter-behavior-section {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-faint);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.enter-behavior-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.enter-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-tertiary);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.enter-option:hover {
+  border-color: var(--border-secondary);
+  background: var(--bg-hover-light);
+}
+
+.enter-option.active {
+  border-color: var(--accent);
+  background: var(--accent-bg-light, rgba(233, 69, 96, 0.06));
+}
+
+.enter-option input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+.enter-option-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}

--- a/src/components/WebSettingsPanel.jsx
+++ b/src/components/WebSettingsPanel.jsx
@@ -162,6 +162,30 @@ export default function WebSettingsPanel({
           Arrow keys continue to work alongside hjkl.
         </div>
       )}
+
+      <div className="enter-behavior-section">
+        <span className="web-settings-label">Enter key in edit mode</span>
+        <div className="enter-behavior-toggle">
+          <label className={`enter-option ${settings.enterNewline ? 'active' : ''}`}>
+            <input
+              type="radio"
+              name="enterBehavior"
+              checked={settings.enterNewline}
+              onChange={() => onUpdateSettings({ enterNewline: true })}
+            />
+            <span className="enter-option-label">Enter = new line, Shift+Enter = exit</span>
+          </label>
+          <label className={`enter-option ${!settings.enterNewline ? 'active' : ''}`}>
+            <input
+              type="radio"
+              name="enterBehavior"
+              checked={!settings.enterNewline}
+              onChange={() => onUpdateSettings({ enterNewline: false })}
+            />
+            <span className="enter-option-label">Enter = exit, Shift+Enter = new line</span>
+          </label>
+        </div>
+      </div>
     </div>
   );
 

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -5,6 +5,7 @@ const STORAGE_KEY = 'treenote-settings';
 const DEFAULT_SETTINGS = {
   keybindingScheme: 'arrows',
   theme: 'dark',
+  enterNewline: true,
 };
 
 function loadSettings() {

--- a/tests/issue-31.spec.js
+++ b/tests/issue-31.spec.js
@@ -1,0 +1,213 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_URL = 'https://etfkdcsoazbxiqzsjkrh.supabase.co';
+
+const fakeSession = {
+  access_token: 'fake-token',
+  refresh_token: 'fake-refresh',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: 'test-user-id',
+    email: 'test@test.com',
+    aud: 'authenticated',
+    role: 'authenticated',
+  },
+};
+
+async function setupMocks(page) {
+  await page.route(`${SUPABASE_URL}/auth/v1/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fakeSession),
+    });
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/user_trees*`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    }
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/user_queues*`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    }
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/tree_backups*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.addInitScript((url) => {
+    const storageKey = `sb-${new URL(url).hostname.split('.')[0]}-auth-token`;
+    const session = {
+      access_token: 'fake-token',
+      refresh_token: 'fake-refresh',
+      expires_in: 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'bearer',
+      user: {
+        id: 'test-user-id',
+        email: 'test@test.com',
+        aud: 'authenticated',
+        role: 'authenticated',
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify(session));
+  }, SUPABASE_URL);
+}
+
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('issue 31: Enter creates newline by default, Shift+Enter exits edit mode', async ({ page }) => {
+  await setupMocks(page);
+  await page.goto('http://localhost:5173');
+
+  await page.waitForSelector('.app', { timeout: 15000 });
+  await page.waitForSelector('.node-box', { timeout: 10000 });
+
+  // Verify the legend is visible with categories
+  await expect(page.locator('.hotkey-legend')).toBeVisible();
+  await expect(page.locator('.legend-category').first()).toBeVisible();
+  await expect(page.locator('.legend-divider').first()).toBeVisible();
+
+  // Enter edit mode on the first node
+  await page.keyboard.press('Enter');
+  await pause(300);
+
+  // Should now be in edit mode with a textarea visible
+  const textarea = page.locator('.node-text-input');
+  await expect(textarea).toBeVisible();
+
+  // Verify the edit mode legend shows the correct keys
+  const legendText = await page.locator('.hotkey-legend').innerText();
+  expect(legendText.toLowerCase()).toContain('edit mode');
+  // Default enterNewline=true: Enter = new line, Shift+Enter = exit
+  expect(legendText).toContain('Shift+Enter');
+
+  // Get the current text value
+  const originalText = await textarea.inputValue();
+
+  // Press Enter — should insert a newline (NOT exit edit mode)
+  await textarea.press('Enter');
+  await pause(200);
+
+  // Textarea should still be visible (still in edit mode)
+  await expect(textarea).toBeVisible();
+
+  // The text should now contain a newline
+  const textAfterEnter = await textarea.inputValue();
+  expect(textAfterEnter).toContain('\n');
+
+  // Now press Shift+Enter — should exit edit mode
+  await page.keyboard.press('Shift+Enter');
+  await pause(300);
+
+  // Textarea should no longer be visible (exited edit mode)
+  await expect(page.locator('.node-text-input')).not.toBeVisible();
+
+  // Should be back in visual mode
+  const modeIndicator = page.locator('.mode-indicator');
+  await expect(modeIndicator).toHaveText('visual');
+});
+
+test('issue 31: legend shows categories with dividers in visual mode', async ({ page }) => {
+  await setupMocks(page);
+  await page.goto('http://localhost:5173');
+
+  await page.waitForSelector('.app', { timeout: 15000 });
+  await page.waitForSelector('.node-box', { timeout: 10000 });
+
+  // Check that categories exist
+  const categories = page.locator('.legend-category');
+  const count = await categories.count();
+  expect(count).toBeGreaterThanOrEqual(3);
+
+  // Check that dividers exist
+  const dividers = page.locator('.legend-divider');
+  const dividerCount = await dividers.count();
+  expect(dividerCount).toBeGreaterThanOrEqual(3);
+
+  // Verify specific category names
+  const legendText = await page.locator('.hotkey-legend').innerText();
+  expect(legendText.toLowerCase()).toContain('navigation');
+  expect(legendText.toLowerCase()).toContain('editing');
+  expect(legendText.toLowerCase()).toContain('other');
+});
+
+test('issue 31: toggle enter behavior via settings', async ({ page }) => {
+  await setupMocks(page);
+  await page.goto('http://localhost:5173');
+
+  await page.waitForSelector('.app', { timeout: 15000 });
+  await page.waitForSelector('.node-box', { timeout: 10000 });
+
+  // Open settings
+  await page.keyboard.press('s');
+  await pause(300);
+
+  // Settings panel should be open
+  await expect(page.locator('.web-settings-panel')).toBeVisible();
+
+  // Find and verify the enter behavior section
+  const enterSection = page.locator('.enter-behavior-section');
+  await expect(enterSection).toBeVisible();
+
+  // The first option (Enter = new line) should be active by default
+  const firstOption = page.locator('.enter-option').first();
+  await expect(firstOption).toHaveClass(/active/);
+
+  // Click the second option (Enter = exit)
+  const secondOption = page.locator('.enter-option').nth(1);
+  await secondOption.click();
+  await pause(200);
+
+  // Second option should now be active
+  await expect(secondOption).toHaveClass(/active/);
+
+  // Close settings
+  await page.keyboard.press('Escape');
+  await pause(300);
+
+  // Enter edit mode
+  await page.keyboard.press('Enter');
+  await pause(300);
+
+  const textarea = page.locator('.node-text-input');
+  await expect(textarea).toBeVisible();
+
+  // With enterNewline=false, Enter should exit edit mode
+  await page.keyboard.press('Enter');
+  await pause(300);
+
+  // Should have exited edit mode
+  await expect(page.locator('.node-text-input')).not.toBeVisible();
+});


### PR DESCRIPTION
Closes #31

Auto-generated fix by Claude Code agent.

## Issue
When editing stuff "enter" should be new line Instead of exiting back to visual mode. And to add an actual new line, it should be shift Enter. Make this a toggle ale setting, in fact, defaulting to the above.

Make sure this information is reflected in the legend at all times, the hotkey legend. At this point, I also want you to re-organize the legend a little bit more, categorizing them and putting horizontal dividers and also lengthening horizontally the entire legend boundary box.