### PR TITLE
fix: breadcrumbs should just display first line and escape any markdown formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ This keeps CLAUDE.md small (it's always in context) while giving Claude enough b
 - `npm run build` — production build (must pass before committing)
 - `npx playwright test` — run tests with video recording
 - Tests mock Supabase auth via `page.route()` and `page.addInitScript()` — no real account needed.
+- **Tests must inject tree data that exercises the fix.** Returning `[]` for `user_trees` loads the default tree, which may not contain the content needed to verify the bug. Inject a custom tree via the mock route (see `capture-media.spec.js` for the pattern).
 
 ## Autofix Pipeline
 

--- a/docs/autofix.md
+++ b/docs/autofix.md
@@ -94,6 +94,7 @@ This auto-removes merged issue worktrees, then lists non-issue worktrees (agent-
 ## Rules for Modifying
 - The prompt template in `fix-issue.sh` tells Claude what to do. Update it if you add new conventions (e.g., new test patterns, new file locations).
 - If you change the Playwright test mock pattern, update both the prompt template and the existing test files.
+- **Video proof must visually demonstrate the fix.** Tests must inject tree data containing the specific content that triggers the bug (e.g., markdown-formatted nodes to prove breadcrumbs strip formatting). Returning `[]` for `user_trees` loads the default tree — which won't contain the right content. Use the `capture-media.spec.js` pattern: return `{ tree_data: customTree, version: 1 }` from the mock route.
 - The daemon polls every 30 seconds (`INTERVAL=30`). Claude gets 30 minutes (`CLAUDE_TIMEOUT=1800`).
 - Max retries is 2 (`MAX_RETRIES=2`). After that, issues get `needs-human`.
 - Branch names use `fix-issue-N` (flat, no slashes). Claude's `--worktree` flag breaks with slashes in branch names.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,7 +181,18 @@ export default function App({ session }) {
     const crumbs = [];
     let nodes = tree;
     for (const idx of path) {
-      crumbs.push(nodes[idx].text);
+      const firstLine = (nodes[idx].text || '').split('\n')[0];
+      const plain = firstLine
+        .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')   // images
+        .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // links
+        .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2')   // bold/italic
+        .replace(/~~(.*?)~~/g, '$1')                  // strikethrough
+        .replace(/`([^`]+)`/g, '$1')                  // inline code
+        .replace(/^#{1,6}\s+/, '')                     // headings
+        .replace(/^>\s?/gm, '')                        // blockquotes
+        .replace(/^[-*+]\s+/, '')                      // list markers
+        .replace(/^\d+\.\s+/, '');                     // ordered list markers
+      crumbs.push(plain);
       nodes = nodes[idx].children;
     }
     return crumbs;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,19 +181,24 @@ export default function App({ session }) {
     const crumbs = [];
     let nodes = tree;
     for (const idx of path) {
-      const firstLine = (nodes[idx].text || '').split('\n')[0];
-      const plain = firstLine
-        .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')   // images
-        .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // links
-        .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2')   // bold/italic
-        .replace(/~~(.*?)~~/g, '$1')                  // strikethrough
-        .replace(/`([^`]+)`/g, '$1')                  // inline code
-        .replace(/^#{1,6}\s+/, '')                     // headings
-        .replace(/^>\s?/gm, '')                        // blockquotes
-        .replace(/^[-*+]\s+/, '')                      // list markers
-        .replace(/^\d+\.\s+/, '');                     // ordered list markers
-      crumbs.push(plain);
-      nodes = nodes[idx].children;
+      const node = nodes[idx];
+      const firstLine = (node.text || '').split('\n')[0];
+      if (node.markdown) {
+        const plain = firstLine
+          .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')   // images
+          .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // links
+          .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2')   // bold/italic
+          .replace(/~~(.*?)~~/g, '$1')                  // strikethrough
+          .replace(/`([^`]+)`/g, '$1')                  // inline code
+          .replace(/^#{1,6}\s+/, '')                     // headings
+          .replace(/^>\s?/gm, '')                        // blockquotes
+          .replace(/^[-*+]\s+/, '')                      // list markers
+          .replace(/^\d+\.\s+/, '');                     // ordered list markers
+        crumbs.push(plain);
+      } else {
+        crumbs.push(firstLine);
+      }
+      nodes = node.children;
     }
     return crumbs;
   }, [tree, path]);

--- a/tests/issue-47.spec.js
+++ b/tests/issue-47.spec.js
@@ -1,0 +1,193 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_URL = 'https://etfkdcsoazbxiqzsjkrh.supabase.co';
+
+const fakeSession = {
+  access_token: 'fake-token',
+  refresh_token: 'fake-refresh',
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: {
+    id: 'test-user-id',
+    email: 'test@test.com',
+    aud: 'authenticated',
+    role: 'authenticated',
+  },
+};
+
+async function setupMocks(page) {
+  await page.route(`${SUPABASE_URL}/auth/v1/token*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fakeSession),
+    });
+  });
+
+  await page.route(`${SUPABASE_URL}/auth/v1/user*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fakeSession.user),
+    });
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/user_trees*`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    }
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/user_queues*`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    }
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/tree_backups*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.addInitScript((url) => {
+    const storageKey = `sb-${new URL(url).hostname.split('.')[0]}-auth-token`;
+    const session = {
+      access_token: 'fake-token',
+      refresh_token: 'fake-refresh',
+      expires_in: 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'bearer',
+      user: {
+        id: 'test-user-id',
+        email: 'test@test.com',
+        aud: 'authenticated',
+        role: 'authenticated',
+      },
+    };
+    localStorage.setItem(storageKey, JSON.stringify(session));
+  }, SUPABASE_URL);
+}
+
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('issue 47: breadcrumbs show first line only and escape markdown', async ({ page }) => {
+  await setupMocks(page);
+  await page.goto('/');
+
+  await page.waitForSelector('.app', { timeout: 10000 });
+  await page.waitForSelector('.node-box', { timeout: 10000 });
+  await pause(500);
+
+  // The default tree has "Welcome to Treenote" as root with children.
+  // Navigate into it by pressing Enter/Right to drill down.
+  await page.keyboard.press('ArrowRight');
+  await pause(500);
+
+  // Now breadcrumbs should be visible
+  const breadcrumb = page.locator('.breadcrumb');
+  await expect(breadcrumb).toBeVisible({ timeout: 5000 });
+
+  // Breadcrumb text should not contain markdown formatting characters
+  const breadcrumbText = await breadcrumb.textContent();
+  console.log('breadcrumb text:', breadcrumbText);
+
+  // Each breadcrumb item should only show plain text (no markdown syntax)
+  const items = page.locator('.breadcrumb-item');
+  const count = await items.count();
+  for (let i = 0; i < count; i++) {
+    const text = await items.nth(i).textContent();
+    console.log(`breadcrumb item ${i}:`, JSON.stringify(text));
+
+    // Should not contain raw markdown formatting
+    expect(text).not.toMatch(/^#{1,6}\s/);       // no heading markers
+    expect(text).not.toMatch(/\*\*.+\*\*/);       // no bold markers
+    expect(text).not.toMatch(/\[.+\]\(.+\)/);     // no link syntax
+    expect(text).not.toMatch(/`[^`]+`/);           // no inline code
+
+    // Should not contain newlines (first line only)
+    expect(text).not.toContain('\n');
+  }
+
+  // Now let's create a node with markdown and multi-line text, then navigate into it
+  // to verify breadcrumbs strip formatting from user content too.
+  // Go back to root first
+  await page.keyboard.press('ArrowLeft');
+  await pause(500);
+
+  // Create a new node with markdown text
+  await page.keyboard.press('o');  // create sibling below
+  await pause(300);
+
+  // Type markdown-formatted multi-line text
+  await page.keyboard.type('# Heading Node');
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('second line of text');
+  await pause(300);
+
+  // Exit edit mode
+  await page.keyboard.press('Escape');
+  await pause(300);
+
+  // Add a child to this node so we can navigate into it
+  await page.keyboard.press('Tab');  // indent to make it a child... or create child
+  await pause(300);
+
+  // Create a child node
+  await page.keyboard.press('o');
+  await pause(300);
+  await page.keyboard.type('child node');
+  await page.keyboard.press('Escape');
+  await pause(300);
+
+  // Navigate into the parent to see breadcrumbs
+  // First go up to the parent
+  await page.keyboard.press('ArrowUp');
+  await pause(300);
+
+  // Drill into it
+  await page.keyboard.press('ArrowRight');
+  await pause(500);
+
+  // Check breadcrumbs again
+  const breadcrumb2 = page.locator('.breadcrumb');
+  await expect(breadcrumb2).toBeVisible({ timeout: 5000 });
+
+  const items2 = page.locator('.breadcrumb-item');
+  const count2 = await items2.count();
+  for (let i = 0; i < count2; i++) {
+    const text = await items2.nth(i).textContent();
+    console.log(`breadcrumb2 item ${i}:`, JSON.stringify(text));
+
+    // Should not contain heading markers
+    expect(text).not.toMatch(/^#/);
+    // Should not contain newlines
+    expect(text).not.toContain('\n');
+    // Should not contain "second line"
+    expect(text).not.toContain('second line');
+  }
+});

--- a/tests/issue-47.spec.js
+++ b/tests/issue-47.spec.js
@@ -15,20 +15,50 @@ const fakeSession = {
   },
 };
 
+// Tree with markdown-formatted nodes to verify breadcrumb stripping
+const markdownTree = [
+  {
+    text: '# Project Overview\nThis is the second line',
+    checked: false,
+    children: [
+      {
+        text: '**Bold Task** with extra info',
+        checked: false,
+        children: [
+          { text: 'plain leaf', checked: false, children: [] },
+        ],
+      },
+      {
+        text: '[Link Text](https://example.com)',
+        checked: false,
+        children: [
+          { text: 'another leaf', checked: false, children: [] },
+        ],
+      },
+      {
+        text: '`inline code` node\nline two here',
+        checked: false,
+        children: [
+          { text: 'deep leaf', checked: false, children: [] },
+        ],
+      },
+      {
+        text: '## Sub-heading with ~~strikethrough~~',
+        checked: false,
+        children: [
+          { text: 'child', checked: false, children: [] },
+        ],
+      },
+    ],
+  },
+];
+
 async function setupMocks(page) {
-  await page.route(`${SUPABASE_URL}/auth/v1/token*`, async (route) => {
+  await page.route(`${SUPABASE_URL}/auth/v1/**`, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(fakeSession),
-    });
-  });
-
-  await page.route(`${SUPABASE_URL}/auth/v1/user*`, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(fakeSession.user),
     });
   });
 
@@ -38,13 +68,16 @@ async function setupMocks(page) {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([]),
+        body: JSON.stringify({
+          tree_data: markdownTree,
+          version: 1,
+        }),
       });
     } else {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({}),
+        body: JSON.stringify({ version: 2 }),
       });
     }
   });
@@ -55,7 +88,7 @@ async function setupMocks(page) {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([]),
+        body: JSON.stringify({ queue_data: null, version: 1 }),
       });
     } else {
       await route.fulfill({
@@ -103,91 +136,93 @@ test('issue 47: breadcrumbs show first line only and escape markdown', async ({ 
   await page.waitForSelector('.node-box', { timeout: 10000 });
   await pause(500);
 
-  // The default tree has "Welcome to Treenote" as root with children.
-  // Navigate into it by pressing Enter/Right to drill down.
+  // The tree root is "# Project Overview\nThis is the second line"
+  // Navigate into it to see breadcrumbs
   await page.keyboard.press('ArrowRight');
   await pause(500);
 
-  // Now breadcrumbs should be visible
+  // Breadcrumbs should be visible — root crumb should be stripped
   const breadcrumb = page.locator('.breadcrumb');
   await expect(breadcrumb).toBeVisible({ timeout: 5000 });
 
-  // Breadcrumb text should not contain markdown formatting characters
-  const breadcrumbText = await breadcrumb.textContent();
-  console.log('breadcrumb text:', breadcrumbText);
-
-  // Each breadcrumb item should only show plain text (no markdown syntax)
+  // Check root breadcrumb item: should show "Project Overview", not "# Project Overview"
   const items = page.locator('.breadcrumb-item');
-  const count = await items.count();
-  for (let i = 0; i < count; i++) {
-    const text = await items.nth(i).textContent();
-    console.log(`breadcrumb item ${i}:`, JSON.stringify(text));
+  const rootText = await items.first().textContent();
+  console.log('root breadcrumb:', JSON.stringify(rootText));
 
-    // Should not contain raw markdown formatting
-    expect(text).not.toMatch(/^#{1,6}\s/);       // no heading markers
-    expect(text).not.toMatch(/\*\*.+\*\*/);       // no bold markers
-    expect(text).not.toMatch(/\[.+\]\(.+\)/);     // no link syntax
-    expect(text).not.toMatch(/`[^`]+`/);           // no inline code
+  // Must not contain heading marker or second line
+  expect(rootText).not.toMatch(/^#/);
+  expect(rootText).not.toContain('second line');
+  expect(rootText).toContain('Project Overview');
 
-    // Should not contain newlines (first line only)
-    expect(text).not.toContain('\n');
-  }
-
-  // Now let's create a node with markdown and multi-line text, then navigate into it
-  // to verify breadcrumbs strip formatting from user content too.
-  // Go back to root first
-  await page.keyboard.press('ArrowLeft');
-  await pause(500);
-
-  // Create a new node with markdown text
-  await page.keyboard.press('o');  // create sibling below
-  await pause(300);
-
-  // Type markdown-formatted multi-line text
-  await page.keyboard.type('# Heading Node');
-  await page.keyboard.press('Enter');
-  await page.keyboard.type('second line of text');
-  await pause(300);
-
-  // Exit edit mode
-  await page.keyboard.press('Escape');
-  await pause(300);
-
-  // Add a child to this node so we can navigate into it
-  await page.keyboard.press('Tab');  // indent to make it a child... or create child
-  await pause(300);
-
-  // Create a child node
-  await page.keyboard.press('o');
-  await pause(300);
-  await page.keyboard.type('child node');
-  await page.keyboard.press('Escape');
-  await pause(300);
-
-  // Navigate into the parent to see breadcrumbs
-  // First go up to the parent
-  await page.keyboard.press('ArrowUp');
-  await pause(300);
-
-  // Drill into it
+  // Now drill into the bold child: "**Bold Task** with extra info"
   await page.keyboard.press('ArrowRight');
   await pause(500);
 
-  // Check breadcrumbs again
-  const breadcrumb2 = page.locator('.breadcrumb');
-  await expect(breadcrumb2).toBeVisible({ timeout: 5000 });
-
   const items2 = page.locator('.breadcrumb-item');
   const count2 = await items2.count();
+  // The last non-current crumb should be the bold node, stripped
   for (let i = 0; i < count2; i++) {
     const text = await items2.nth(i).textContent();
-    console.log(`breadcrumb2 item ${i}:`, JSON.stringify(text));
+    console.log(`breadcrumb item ${i}:`, JSON.stringify(text));
 
-    // Should not contain heading markers
-    expect(text).not.toMatch(/^#/);
-    // Should not contain newlines
+    // No markdown syntax in any breadcrumb
+    expect(text).not.toMatch(/\*\*/);
+    expect(text).not.toMatch(/^#{1,6}\s/);
+    expect(text).not.toMatch(/\[.+\]\(.+\)/);
+    expect(text).not.toMatch(/`[^`]+`/);
+    expect(text).not.toMatch(/~~/);
     expect(text).not.toContain('\n');
-    // Should not contain "second line"
-    expect(text).not.toContain('second line');
+  }
+
+  // Go back and navigate into the link node
+  await page.keyboard.press('ArrowLeft');
+  await pause(300);
+  await page.keyboard.press('ArrowDown'); // move to link node
+  await pause(300);
+  await page.keyboard.press('ArrowRight'); // drill in
+  await pause(500);
+
+  const linkCrumbs = page.locator('.breadcrumb-item');
+  const linkCount = await linkCrumbs.count();
+  for (let i = 0; i < linkCount; i++) {
+    const text = await linkCrumbs.nth(i).textContent();
+    console.log(`link breadcrumb ${i}:`, JSON.stringify(text));
+    expect(text).not.toMatch(/\[.+\]\(.+\)/);
+    expect(text).not.toContain('https://');
+  }
+
+  // Go back and navigate into the inline code node
+  await page.keyboard.press('ArrowLeft');
+  await pause(300);
+  await page.keyboard.press('ArrowDown'); // move to code node
+  await pause(300);
+  await page.keyboard.press('ArrowRight'); // drill in
+  await pause(500);
+
+  const codeCrumbs = page.locator('.breadcrumb-item');
+  const codeCount = await codeCrumbs.count();
+  for (let i = 0; i < codeCount; i++) {
+    const text = await codeCrumbs.nth(i).textContent();
+    console.log(`code breadcrumb ${i}:`, JSON.stringify(text));
+    expect(text).not.toMatch(/`[^`]+`/);
+    expect(text).not.toContain('line two');
+  }
+
+  // Go back and navigate into the sub-heading + strikethrough node
+  await page.keyboard.press('ArrowLeft');
+  await pause(300);
+  await page.keyboard.press('ArrowDown'); // move to sub-heading node
+  await pause(300);
+  await page.keyboard.press('ArrowRight'); // drill in
+  await pause(500);
+
+  const headCrumbs = page.locator('.breadcrumb-item');
+  const headCount = await headCrumbs.count();
+  for (let i = 0; i < headCount; i++) {
+    const text = await headCrumbs.nth(i).textContent();
+    console.log(`heading breadcrumb ${i}:`, JSON.stringify(text));
+    expect(text).not.toMatch(/^##/);
+    expect(text).not.toMatch(/~~/);
   }
 });

--- a/tests/issue-47.spec.js
+++ b/tests/issue-47.spec.js
@@ -15,15 +15,19 @@ const fakeSession = {
   },
 };
 
-// Tree with markdown-formatted nodes to verify breadcrumb stripping
+// Tree with markdown-formatted nodes to verify breadcrumb stripping.
+// Nodes with markdown: true should have formatting stripped;
+// nodes without markdown should keep their text as-is (first line only).
 const markdownTree = [
   {
     text: '# Project Overview\nThis is the second line',
     checked: false,
+    markdown: true,
     children: [
       {
         text: '**Bold Task** with extra info',
         checked: false,
+        markdown: true,
         children: [
           { text: 'plain leaf', checked: false, children: [] },
         ],
@@ -31,6 +35,7 @@ const markdownTree = [
       {
         text: '[Link Text](https://example.com)',
         checked: false,
+        markdown: true,
         children: [
           { text: 'another leaf', checked: false, children: [] },
         ],
@@ -38,17 +43,18 @@ const markdownTree = [
       {
         text: '`inline code` node\nline two here',
         checked: false,
+        markdown: true,
         children: [
           { text: 'deep leaf', checked: false, children: [] },
         ],
       },
-      {
-        text: '## Sub-heading with ~~strikethrough~~',
-        checked: false,
-        children: [
-          { text: 'child', checked: false, children: [] },
-        ],
-      },
+    ],
+  },
+  {
+    text: '**not-markdown node**\nsecond line',
+    checked: false,
+    children: [
+      { text: 'child of non-md', checked: false, children: [] },
     ],
   },
 ];
@@ -209,20 +215,33 @@ test('issue 47: breadcrumbs show first line only and escape markdown', async ({ 
     expect(text).not.toContain('line two');
   }
 
-  // Go back and navigate into the sub-heading + strikethrough node
-  await page.keyboard.press('ArrowLeft');
+  // Navigate back to root level, then into the non-markdown node
+  // The non-markdown node is the 2nd top-level item: "**not-markdown node**\nsecond line"
+  // It does NOT have markdown: true, so ** should be preserved and only first line shown
+  await page.keyboard.press('ArrowLeft'); // back to root's children
   await pause(300);
-  await page.keyboard.press('ArrowDown'); // move to sub-heading node
+  await page.keyboard.press('ArrowLeft'); // back to root level
   await pause(300);
-  await page.keyboard.press('ArrowRight'); // drill in
+  await page.keyboard.press('ArrowLeft'); // ensure at root (no-op if already there)
+  await pause(300);
+  await page.keyboard.press('ArrowDown'); // move to 2nd root node
+  await pause(300);
+  await page.keyboard.press('ArrowRight'); // drill into non-markdown node
   await pause(500);
 
-  const headCrumbs = page.locator('.breadcrumb-item');
-  const headCount = await headCrumbs.count();
-  for (let i = 0; i < headCount; i++) {
-    const text = await headCrumbs.nth(i).textContent();
-    console.log(`heading breadcrumb ${i}:`, JSON.stringify(text));
-    expect(text).not.toMatch(/^##/);
-    expect(text).not.toMatch(/~~/);
+  const nonMdCrumbs = page.locator('.breadcrumb-item');
+  const nonMdCount = await nonMdCrumbs.count();
+  let foundNonMdCrumb = false;
+  for (let i = 0; i < nonMdCount; i++) {
+    const text = await nonMdCrumbs.nth(i).textContent();
+    console.log(`non-md breadcrumb ${i}:`, JSON.stringify(text));
+    if (text.includes('not-markdown')) {
+      foundNonMdCrumb = true;
+      // ** should be preserved since this is not a markdown node
+      expect(text).toContain('**');
+      // second line should not appear (first-line-only still applies)
+      expect(text).not.toContain('second line');
+    }
   }
+  expect(foundNonMdCrumb).toBe(true);
 });


### PR DESCRIPTION
Closes #47

Auto-generated fix by Claude Code agent.

## Issue
<img width="997" height="89" alt="Image" src="https://github.com/user-attachments/assets/7daf3e52-f9ad-4e81-b543-3efe7103dde4" />