### PR TITLE
fix: Create a design doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+dist-viewer/
+public/viewer-template.html
 .claude/
 .env.local
 .vercel/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ This keeps CLAUDE.md small (it's always in context) while giving Claude enough b
 - `docs/mobile-design.md` — mobile app design spec: screen architecture, gestures, interaction patterns, implementation plan.
 - `docs/image-mode.md` — image mode: node data model, keybinding, Supabase Storage upload, drag-and-drop, rendering spec.
 - `docs/exploration.md` — exploration mode: diverge-then-converge workflow for research chats, phase signals, rules of engagement.
+- `docs/html-export-design.md` — self-contained HTML export: viewer build, runtime template substitution, `Cmd+Shift+E` trigger.
 
 ### Maintenance rules
 1. **Before touching an area**: read its area doc if one exists.

--- a/docs/html-export-design.md
+++ b/docs/html-export-design.md
@@ -1,6 +1,8 @@
 # Self-Contained HTML Export — Design Spec
 
-> **Status**: design only, not implemented. Issue #61.
+> **Status**: implemented (Phase 1+2). Issue #61.
+>
+> Source files: `vite.viewer.config.js`, `src/viewer/`, `src/exportHtml.js`. Trigger: `Cmd/Ctrl+Shift+E`, or the Export tab in `WebSettingsPanel.jsx`. Build: `npm run build:viewer` produces `public/viewer-template.html`; the main `npm run build` chains it automatically. At runtime `exportHtml.js` fetches that template and substitutes the tree payload at the `<!--TREENOTE_DATA-->` placeholder.
 
 ## Overview
 

--- a/docs/html-export-design.md
+++ b/docs/html-export-design.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Let the user pick any node in their tree and export the subtree rooted at it as a **single self-contained `.html` file** — one file, no server, no Supabase, no build step. Open the file in any browser and it behaves like a read-only, navigable mini-treenote: same look, same arrow-key navigation, same expand/collapse, same markdown/image rendering. Drop it in a Slack DM, attach it to an email, host it on a static page — it just works.
+Let the user pick any node in their tree and export the subtree rooted at it as a **single self-contained `.html` file** — one file, no server, no Supabase, no build step. Open the file in any browser and it behaves like a read-only, navigable mini-treenote: same look, same arrow-key navigation, same expand/collapse, same markdown rendering. Drop it in a Slack DM, attach it to an email, host it on a static page — it just works.
 
 The export is a **read-only snapshot**. No editing, no save, no auth, no network calls. If the original tree changes later, you re-export.
 
@@ -37,7 +37,7 @@ When someone opens the exported `.html` file:
 - Same dark/light theme the exporter was using (theme is baked in).
 - Same three-column layout (parent / current / children) on desktop, same single-column stack on mobile.
 - Arrow keys / `hjkl` navigate exactly as in the live app.
-- Markdown nodes render as markdown. Image nodes render the embedded image.
+- Markdown nodes render as markdown.
 - Deadlines, priorities, checked state — all visible.
 - A small banner at the top: "Read-only snapshot · Exported from Treenote · 2026-05-01 · [treenote.app]". The banner is dismissable.
 - **No** edit affordances. Pressing edit keys (Enter, `i`, etc.) does nothing or shows a tiny "read-only" toast.
@@ -120,19 +120,6 @@ Key properties:
 - The placeholder `<!--TREENOTE_DATA-->` is a stable string we reserve in the viewer's `index.html`.
 - `</` inside JSON is escaped to prevent HTML injection if a node's text contains `</script>`.
 
-### Image handling
-
-Image nodes in treenote store a Supabase Storage URL (see `docs/image-mode.md`). For an export to be self-contained, every image must be **inlined as a data URL**.
-
-At export time:
-1. Walk the subtree, collect all `imageUrl` values.
-2. Fetch each image, convert to base64, replace `imageUrl` with the data URL in the export payload.
-3. Show progress in the toast: "Exporting (3/12 images)…"
-
-Caveats:
-- Large image-heavy trees produce huge HTML files. We'll add a soft warning when the projected file size exceeds 10 MB.
-- If an image fails to fetch (CORS, deleted), we replace it with a placeholder data URL and continue.
-
 ### What gets stripped
 
 The viewer bundle excludes:
@@ -178,7 +165,6 @@ Phased so we ship something useful early.
 - New Vite config, viewer entry, single-file plugin.
 - Viewer renders the static tree (no navigation yet — just a flat indented outline).
 - Export keybinding + toast.
-- No image inlining (image nodes show a "image not exported" placeholder).
 - Ship it. This already covers the "share it with others" use case for text-only trees.
 
 ### Phase 2: parity navigation
@@ -187,7 +173,6 @@ Phased so we ship something useful early.
 - Read-only legend.
 
 ### Phase 3: rich content
-- Image inlining with progress toast.
 - Markdown nodes render exactly as in the live app.
 - File-size warning for large exports.
 
@@ -215,3 +200,16 @@ Phased so we ship something useful early.
 - PDF / image export. HTML only.
 - Server-side generation. Stays client-only — no new backend surface.
 - Authentication / encryption of exports. The file is whatever the exporter shares; standard web sharing rules apply.
+
+---
+
+## Future: image nodes
+
+Image mode is itself only a design doc today (see `docs/image-mode.md`) — there are no image nodes in the tree yet. So this spec deliberately says nothing about how to export them. **If/when image mode actually lands**, this design will need a follow-up section covering:
+
+- Walking the subtree to collect `imageUrl` values and fetching each one (Supabase Storage URLs are public so a plain `fetch` works).
+- Inlining each image as a base64 data URL in the export payload, so the file stays self-contained.
+- Progress UI for image-heavy trees and a soft file-size warning.
+- Fallback when an image can't be fetched (CORS, deleted from storage).
+
+None of that is in scope here — it's listed only so a future contributor implementing image mode knows to revisit this doc.

--- a/docs/html-export-design.md
+++ b/docs/html-export-design.md
@@ -1,0 +1,217 @@
+# Self-Contained HTML Export — Design Spec
+
+> **Status**: design only, not implemented. Issue #61.
+
+## Overview
+
+Let the user pick any node in their tree and export the subtree rooted at it as a **single self-contained `.html` file** — one file, no server, no Supabase, no build step. Open the file in any browser and it behaves like a read-only, navigable mini-treenote: same look, same arrow-key navigation, same expand/collapse, same markdown/image rendering. Drop it in a Slack DM, attach it to an email, host it on a static page — it just works.
+
+The export is a **read-only snapshot**. No editing, no save, no auth, no network calls. If the original tree changes later, you re-export.
+
+---
+
+## User Experience
+
+### Trigger
+Two equivalent triggers:
+
+1. **Keybinding**: `Cmd+Shift+E` (or `Ctrl+Shift+E`) in visual mode. Exports the **selected node** (the current cursor in the graph) and its full subtree.
+2. **Settings panel**: a new "Export" tab in `WebSettingsPanel.jsx` with a single "Export current node as HTML" button. Useful for discoverability and for users who don't memorize keys.
+
+We deliberately do **not** add a top-bar button. Treenote's UI is keyboard-first and visually minimal — issue #61 explicitly calls out "without cluttering things". The keybinding is the primary path; the settings tab is the discovery path.
+
+### Flow
+
+1. User selects a node in the graph (normal navigation).
+2. User hits `Cmd+Shift+E`.
+3. A small toast appears: "Exporting…"
+4. Browser triggers a download: `treenote-<root-text-slug>-<YYYYMMDD>.html` (e.g. `treenote-grocery-list-20260501.html`).
+5. Toast updates: "Exported ✓".
+
+No modal, no confirmation, no options dialog on the first version. If we later need format options (include checked items? expand all?), they can live in the settings tab.
+
+### What the recipient sees
+
+When someone opens the exported `.html` file:
+
+- Same dark/light theme the exporter was using (theme is baked in).
+- Same three-column layout (parent / current / children) on desktop, same single-column stack on mobile.
+- Arrow keys / `hjkl` navigate exactly as in the live app.
+- Markdown nodes render as markdown. Image nodes render the embedded image.
+- Deadlines, priorities, checked state — all visible.
+- A small banner at the top: "Read-only snapshot · Exported from Treenote · 2026-05-01 · [treenote.app]". The banner is dismissable.
+- **No** edit affordances. Pressing edit keys (Enter, `i`, etc.) does nothing or shows a tiny "read-only" toast.
+- **No** queue, no settings panel, no auth. Exploration mode and other backend-touching features are absent.
+
+---
+
+## Technical Design
+
+### Big picture
+
+The exported HTML file is a **standalone Vite build** of a stripped-down treenote viewer, with the tree data inlined as a `<script>` blob. Everything — JS, CSS, fonts, images — is base64-embedded into one HTML file.
+
+```
+exported.html
+├── <style>…all CSS inlined…</style>
+├── <script>window.__TREENOTE_DATA__ = {tree, theme, exportedAt};</script>
+├── <script>…React + viewer bundle, inlined…</script>
+└── <div id="root"></div>
+```
+
+There is no separate `assets/` directory. One file is the deliverable.
+
+### Two builds, one repo
+
+We add a **second Vite entry point** that builds a viewer-only bundle:
+
+```
+src/
+  main.jsx               # existing — full app
+  viewer/
+    main.jsx             # new — viewer-only entry
+    Viewer.jsx           # read-only tree renderer
+    viewer.html          # shell with inlined data placeholder
+```
+
+The viewer reuses the existing rendering components (`NodeContent.jsx`, `Linkify.jsx`, deadline badges, etc.) but **does not import** `App.jsx`, `storage.js`, `supabaseClient.js`, `useKeyboard.js` (full version), or any auth/queue/eject/sync code. It owns a tiny keyboard handler that only does navigation.
+
+`vite.config.js` gets a new build target (`vite build --config vite.viewer.config.js`) that:
+- Outputs to `dist-viewer/`.
+- Uses [`vite-plugin-singlefile`](https://github.com/richardtallent/vite-plugin-singlefile) (or our own equivalent) to inline all assets into a single HTML file.
+- Produces `dist-viewer/viewer.html` — the **template** the runtime uses to generate exports.
+
+This template ships with the main app (copied into `public/` or imported as a raw asset).
+
+### Export at runtime
+
+When the user triggers export:
+
+```js
+// src/exportHtml.js
+import viewerTemplate from './viewer-template.html?raw';
+
+export function exportNodeAsHtml(node, theme) {
+  const payload = {
+    tree: stripBackendFields(node),   // strip ids, version, sync metadata
+    theme,                            // 'dark' | 'midnight' | 'light'
+    exportedAt: new Date().toISOString(),
+    sourceUrl: window.location.origin,
+  };
+
+  const html = viewerTemplate.replace(
+    '<!--TREENOTE_DATA-->',
+    `<script>window.__TREENOTE_DATA__ = ${JSON.stringify(payload).replace(/</g, '\\u003c')};</script>`
+  );
+
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = makeFilename(node);
+  a.click();
+  URL.revokeObjectURL(url);
+}
+```
+
+Key properties:
+- Pure client-side. No server roundtrip.
+- The viewer template is fetched once at build time (Vite `?raw` import), bundled into the main app.
+- The placeholder `<!--TREENOTE_DATA-->` is a stable string we reserve in the viewer's `index.html`.
+- `</` inside JSON is escaped to prevent HTML injection if a node's text contains `</script>`.
+
+### Image handling
+
+Image nodes in treenote store a Supabase Storage URL (see `docs/image-mode.md`). For an export to be self-contained, every image must be **inlined as a data URL**.
+
+At export time:
+1. Walk the subtree, collect all `imageUrl` values.
+2. Fetch each image, convert to base64, replace `imageUrl` with the data URL in the export payload.
+3. Show progress in the toast: "Exporting (3/12 images)…"
+
+Caveats:
+- Large image-heavy trees produce huge HTML files. We'll add a soft warning when the projected file size exceeds 10 MB.
+- If an image fails to fetch (CORS, deleted), we replace it with a placeholder data URL and continue.
+
+### What gets stripped
+
+The viewer bundle excludes:
+- Supabase client and all storage code.
+- Auth (`AuthGate.jsx`).
+- Save/load logic, undo/redo, optimistic concurrency.
+- Queue, eject animation, calendar feed, exploration mode, search, settings panels.
+- Mobile Capacitor / widget bridge code.
+- Edit-mode keyboard handlers (`useKeyboard.js` is replaced by a much smaller `useViewerKeyboard.js`).
+
+What stays:
+- Tree rendering: parent / current / children columns, the connecting lines.
+- Slide animation between levels.
+- Theme CSS (`theme.css`, all variables).
+- Markdown rendering (`marked`), `Linkify`, deadline badges.
+- Box-width setting (frozen to whatever the exporter had).
+
+Estimated viewer bundle size: **~80–120 KB gzipped**, vs the current ~194 KB for the full app. React + ReactDOM + marked dominate; the viewer-specific code is tiny.
+
+### Read-only enforcement
+
+The viewer's keyboard handler implements only:
+- `ArrowUp/Down` / `j`/`k` — move selection.
+- `ArrowLeft` / `h` / `Backspace` — go to parent.
+- `ArrowRight` / `l` / `Enter` — go into selected node.
+- `Escape` — go to root.
+- `?` / `l` — toggle a small in-page legend.
+
+Any other key is swallowed. There is no editor component mounted. Even if a malicious recipient pokes at `window.__TREENOTE_DATA__` in devtools, there's no save endpoint to call — the data is local-only.
+
+### Filename and metadata
+
+- Filename: `treenote-<slug>-<YYYYMMDD>.html`, where `slug` is the root node's text, lowercased, non-alphanumerics → `-`, truncated to 40 chars. Falls back to `treenote-export-<YYYYMMDD>.html` if root text is empty.
+- Banner shows: source URL (so recipients can find the live app), export date, exporter's display name (optional, off by default for privacy).
+
+---
+
+## Implementation Plan
+
+Phased so we ship something useful early.
+
+### Phase 1: minimum viable export
+- New Vite config, viewer entry, single-file plugin.
+- Viewer renders the static tree (no navigation yet — just a flat indented outline).
+- Export keybinding + toast.
+- No image inlining (image nodes show a "image not exported" placeholder).
+- Ship it. This already covers the "share it with others" use case for text-only trees.
+
+### Phase 2: parity navigation
+- Port the three-column layout and slide animation to the viewer.
+- Arrow-key navigation matching the live app's behavior.
+- Read-only legend.
+
+### Phase 3: rich content
+- Image inlining with progress toast.
+- Markdown nodes render exactly as in the live app.
+- File-size warning for large exports.
+
+### Phase 4: discoverability
+- "Export" tab in `WebSettingsPanel`.
+- Surface the keybinding in the hotkey legend.
+- Optional: include exporter display name in banner (opt-in).
+
+---
+
+## Open Questions
+
+1. **Privacy of metadata.** Should we strip node `id`s and timestamps, or keep them? Keeping them helps debugging but leaks more info than the recipient needs. Default: strip.
+2. **Checked items.** Do we export them as visible-but-greyed-out, or hide them entirely? Default: visible (it's a snapshot of state, not a TODO list).
+3. **Linked references** (queue items, calendar feeds). Out of scope — those are app features, not part of the tree itself.
+4. **Updates after export.** Do we want a "re-export and overwrite" flow, or is download-only fine? Start with download-only; revisit if users ask.
+5. **Bundle splitting.** Worth code-splitting the viewer template out of the main bundle so users who never export don't pay for it? Probably yes — lazy-load the template via dynamic import on first export.
+
+---
+
+## Non-Goals
+
+- Editing the exported file and re-importing it. Round-trip is out of scope.
+- Multi-tree exports. One subtree per file.
+- PDF / image export. HTML only.
+- Server-side generation. Stays client-only — no new backend surface.
+- Authentication / encryption of exports. The file is whatever the exporter shares; standard web sharing rules apply.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build:viewer": "vite build --config vite.viewer.config.js",
+    "build": "npm run build:viewer && vite build",
     "electron:dev": "concurrently -k \"vite\" \"wait-on http://localhost:5173 && VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "electron:build": "vite build && electron-builder",
     "screenshot": "node scripts/take-screenshots.mjs",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import useSwapAnimation from './hooks/useSwapAnimation';
 import useSettings from './hooks/useSettings';
 import WebSettingsPanel from './components/WebSettingsPanel';
 import { loadUserTree, saveUserTree, loadUserQueue, saveUserQueue, saveBackup, deleteOldBackups } from './storage';
+import { exportNodeAsHtml } from './exportHtml';
 import { supabase } from './supabaseClient';
 import { Capacitor } from '@capacitor/core';
 import './theme.css';
@@ -395,6 +396,19 @@ export default function App({ session }) {
 
   const { prepareSwap } = useSwapAnimation(currentColRef, updateLines);
 
+  const handleExport = useCallback(async (node) => {
+    const target = node || selectedNode;
+    if (!target) return;
+    showToast('Exporting…', 1500);
+    try {
+      await exportNodeAsHtml(target, settings.theme, settings.boxWidth, window.location.origin);
+      showToast('Exported ✓', 1500);
+    } catch (err) {
+      console.error('[export]', err);
+      showToast('Export failed', 2000);
+    }
+  }, [selectedNode, settings.theme, settings.boxWidth, showToast]);
+
   useKeyboard({
     tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen,
     getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, animatingRef, ejectQueueItem,
@@ -408,6 +422,7 @@ export default function App({ session }) {
     keybindingScheme: settings.keybindingScheme,
     webSettingsOpen, setWebSettingsOpen,
     defaultMarkdown: settings.defaultMarkdown,
+    onExport: handleExport,
   });
 
   // Scroll selected item into view
@@ -926,6 +941,8 @@ export default function App({ session }) {
           onClose={() => setWebSettingsOpen(false)}
           settings={settings}
           onUpdateSettings={updateSettings}
+          onExport={() => handleExport(selectedNode)}
+          selectedNodeText={selectedNode?.text || ''}
           electronSettings={window.treenote ? settingsInitial : null}
           onSaveElectronSettings={window.treenote ? ({ path: filePath, physics: newPhysics }) => {
             setPhysics(newPhysics);

--- a/src/components/WebSettingsPanel.jsx
+++ b/src/components/WebSettingsPanel.jsx
@@ -5,6 +5,7 @@ import { BOX_WIDTH_MIN, BOX_WIDTH_MAX } from '../hooks/useSettings';
 const TABS = [
   { id: 'keybindings', label: 'Keybindings' },
   { id: 'appearance', label: 'Appearance' },
+  { id: 'export', label: 'Export' },
 ];
 
 // Only show Electron tab when running in Electron
@@ -64,6 +65,8 @@ export default function WebSettingsPanel({
   onClose,
   settings,
   onUpdateSettings,
+  onExport,
+  selectedNodeText,
   // Electron-specific props
   electronSettings,
   onSaveElectronSettings,
@@ -291,6 +294,45 @@ export default function WebSettingsPanel({
     </div>
   );
 
+  const renderExport = () => {
+    const hasNode = !!(selectedNodeText && selectedNodeText.length > 0);
+    const preview = hasNode
+      ? `Selected: ${selectedNodeText.split('\n')[0].slice(0, 60)}`
+      : 'No node selected. Close this panel and pick one first.';
+    return (
+      <div className="web-settings-section">
+        <div className="web-settings-row">
+          <span className="web-settings-label">Self-contained HTML export</span>
+        </div>
+        <p className="scheme-desc">
+          Download the currently selected node and its subtree as a single
+          self-contained <code>.html</code> file. Open it in any browser — no
+          server, no account, no Treenote install needed. Read-only.
+        </p>
+        <p className="scheme-desc" style={{ opacity: 0.75 }}>{preview}</p>
+        <div className="web-settings-actions" style={{ justifyContent: 'flex-start' }}>
+          <button
+            className="load-btn web-settings-save-btn"
+            disabled={!hasNode || !onExport}
+            onClick={() => {
+              if (onExport) {
+                onExport();
+                onClose();
+              }
+            }}
+          >
+            Export current node as HTML
+          </button>
+        </div>
+        <div className="scheme-note">
+          Tip: press <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> (or
+          <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> on Windows/Linux)
+          anywhere in the app to export the selected node directly.
+        </div>
+      </div>
+    );
+  };
+
   const renderElectron = () => (
     <div className="web-settings-section">
       <div className="web-settings-row">
@@ -364,6 +406,7 @@ export default function WebSettingsPanel({
         <div className="web-settings-body">
           {activeTab === 'keybindings' && renderKeybindings()}
           {activeTab === 'appearance' && renderAppearance()}
+          {activeTab === 'export' && renderExport()}
           {activeTab === 'electron' && renderElectron()}
         </div>
       </div>

--- a/src/exportHtml.js
+++ b/src/exportHtml.js
@@ -1,0 +1,78 @@
+// Runtime HTML export. Fetches the prebuilt single-file viewer template from
+// /viewer-template.html, splices the tree payload in via the
+// <!--TREENOTE_DATA--> placeholder, and triggers a download.
+
+export async function exportNodeAsHtml(node, theme, boxWidth, sourceUrl) {
+  if (!node) throw new Error('no node selected');
+
+  const stripped = stripBackendFields(node);
+  const payload = {
+    // We always export the subtree as a top-level array so the viewer's
+    // path/index logic works the same as the main app.
+    tree: [stripped],
+    theme: theme || 'dark',
+    boxWidth: boxWidth || 400,
+    exportedAt: new Date().toISOString(),
+    sourceUrl: sourceUrl || (typeof window !== 'undefined' ? window.location.origin : ''),
+  };
+
+  const res = await fetch('/viewer-template.html', { cache: 'no-store' });
+  if (!res.ok) throw new Error('viewer template not available');
+  let html = await res.text();
+
+  // Escape `<` to defang any `</script>` substrings inside node text. JSON
+  // strings preserve the escape as a real `<` once parsed.
+  const json = JSON.stringify(payload).replace(/</g, '\\u003c');
+  const inject = `<script>window.__TREENOTE_DATA__ = ${json};</script>`;
+  if (!html.includes('<!--TREENOTE_DATA-->')) {
+    throw new Error('viewer template missing TREENOTE_DATA placeholder');
+  }
+  html = html.replace('<!--TREENOTE_DATA-->', inject);
+
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = makeFilename(node);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer revoke to next tick so the browser has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+// Strip server/runtime-only fields. Keeps content + metadata users see.
+const KEEP_FIELDS = ['text', 'children', 'checked', 'markdown', 'deadline', 'deadlineTime', 'deadlineDuration', 'priority'];
+
+function stripBackendFields(node) {
+  if (!node || typeof node !== 'object') return node;
+  const out = {};
+  for (const key of KEEP_FIELDS) {
+    if (key in node) out[key] = node[key];
+  }
+  // Always normalize children to an array.
+  out.children = Array.isArray(node.children) ? node.children.map(stripBackendFields) : [];
+  // Always include a checked field — NodeMeta inspects it.
+  if (typeof out.checked !== 'boolean') out.checked = !!out.checked;
+  return out;
+}
+
+function makeFilename(node) {
+  const date = formatDate(new Date());
+  const text = (node && typeof node.text === 'string') ? node.text : '';
+  let slug = text
+    .toLowerCase()
+    .slice(0, 60)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  if (!slug) slug = 'export';
+  return `treenote-${slug}-${date}.html`;
+}
+
+function formatDate(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}${m}${day}`;
+}

--- a/src/hooks/useGraphKeys.js
+++ b/src/hooks/useGraphKeys.js
@@ -22,11 +22,19 @@ export default function handleGraphKeys(e, {
   setFocus, setSelectedIndex, setMode, setBackupOpen,
   setCalendarOpen, setCalendarFeedOpen, setLegendVisible,
   setSettingsOpen, setWebSettingsOpen,
-  queue, undo, redo,
+  queue, undo, redo, onExport,
 }) {
   if (animatingRef.current && (isRight(e, scheme) || isLeft(e, scheme))) return;
 
   const isMeta = e.metaKey || e.ctrlKey;
+
+  // Cmd/Ctrl + Shift + E: export current node as self-contained HTML.
+  // Checked before regular letter handling so the modifier combo wins.
+  if (isMeta && e.shiftKey && (e.key === 'E' || e.key === 'e')) {
+    e.preventDefault();
+    if (onExport && selectedNode) onExport(selectedNode);
+    return true;
+  }
 
   // Directional navigation
   if (isUp(e, scheme)) {

--- a/src/hooks/useKeyboard.js
+++ b/src/hooks/useKeyboard.js
@@ -21,6 +21,7 @@ export default function useKeyboard({
   keybindingScheme,
   webSettingsOpen, setWebSettingsOpen,
   defaultMarkdown,
+  onExport,
 }) {
   const scheme = keybindingScheme || 'arrows';
   const insertOpts = defaultMarkdown ? { markdown: true } : {};
@@ -106,11 +107,11 @@ export default function useKeyboard({
         setFocus, setSelectedIndex, setMode, setBackupOpen,
         setCalendarOpen, setCalendarFeedOpen, setLegendVisible,
         setSettingsOpen, setWebSettingsOpen,
-        queue, undo, redo,
+        queue, undo, redo, onExport,
       });
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen, getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, focus, queue, queueIndex, pushUndo, animatingRef, ejectQueueItem, showToast, setSettingsOpen, setDeleteConfirm, setClearCheckedConfirm, setQueue, setQueueIndex, setFocus, setSelectedIndex, setPath, setMode, onSave, setBackupOpen, calendarOpen, setCalendarOpen, calendarFeedOpen, setCalendarFeedOpen, setLegendVisible, scheme, webSettingsOpen, setWebSettingsOpen, insertOpts, prepareSwap]);
+  }, [tree, path, selectedIndex, selectedNode, mode, deleteConfirm, clearCheckedConfirm, settingsOpen, backupOpen, getCurrentNodes, slideNavigate, enterEditMode, undo, redo, applyAction, focus, queue, queueIndex, pushUndo, animatingRef, ejectQueueItem, showToast, setSettingsOpen, setDeleteConfirm, setClearCheckedConfirm, setQueue, setQueueIndex, setFocus, setSelectedIndex, setPath, setMode, onSave, setBackupOpen, calendarOpen, setCalendarOpen, calendarFeedOpen, setCalendarFeedOpen, setLegendVisible, scheme, webSettingsOpen, setWebSettingsOpen, insertOpts, prepareSwap, onExport]);
 }

--- a/src/viewer/Viewer.css
+++ b/src/viewer/Viewer.css
@@ -1,0 +1,106 @@
+/* Viewer-specific overlays — kept tiny on top of the shared App.css/theme.css. */
+
+.viewer-app {
+  /* Same shell, but no auth/queue/toolbar buttons. */
+}
+
+.viewer-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: 12px;
+  letter-spacing: 0.2px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.viewer-banner-text a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.viewer-banner-text a:hover {
+  text-decoration: underline;
+}
+
+.viewer-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+}
+.viewer-banner-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.viewer-toolbar {
+  /* Slim breadcrumb strip — no buttons. */
+  margin-bottom: 12px;
+}
+
+.viewer-toast {
+  /* Same look as the main app toast, just bound to viewer state. */
+}
+
+.viewer-help-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.viewer-help-panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-primary);
+  border-radius: 12px;
+  padding: 24px 28px;
+  min-width: 320px;
+  color: var(--text-primary);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.viewer-help-title {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 12px;
+  color: var(--text-strong);
+}
+
+.viewer-help-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.viewer-help-table td {
+  padding: 6px 8px;
+  color: var(--text-secondary);
+}
+.viewer-help-table td:last-child {
+  text-align: right;
+}
+.viewer-help-table kbd {
+  background: var(--bg-input);
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.viewer-help-hint {
+  margin-top: 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}

--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -1,0 +1,328 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import NodeContent from '../components/NodeContent';
+import NodeMeta from '../components/NodeMeta';
+import useSvgLines from '../hooks/useSvgLines';
+import useSlideAnimation from '../hooks/useSlideAnimation';
+
+// Read-only viewer for an exported tree snapshot.
+// No edit affordances, no Supabase, no auth. The keyboard handler only does
+// navigation; any other key triggers a "read-only" toast.
+export default function Viewer({ data }) {
+  const tree = data.tree || [];
+  const theme = data.theme || 'dark';
+  const boxWidth = data.boxWidth || 400;
+  const sourceUrl = data.sourceUrl || '';
+  const exportedAt = data.exportedAt || '';
+
+  const [path, setPath] = useState([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [bannerVisible, setBannerVisible] = useState(true);
+  const [helpVisible, setHelpVisible] = useState(false);
+  const [toast, setToast] = useState(null);
+  const toastTimerRef = useRef(null);
+
+  // Apply theme + box width once on mount.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    const w = Math.max(200, Math.min(900, Number(boxWidth) || 400));
+    document.documentElement.style.setProperty('--main-box-width', w + 'px');
+  }, [theme, boxWidth]);
+
+  const showToast = useCallback((msg, ms = 1200) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setToast(msg);
+    toastTimerRef.current = setTimeout(() => setToast(null), ms);
+  }, []);
+
+  const getCurrentNodes = useCallback(() => {
+    let nodes = tree;
+    for (const idx of path) {
+      if (!nodes[idx]) return [];
+      nodes = nodes[idx].children || [];
+    }
+    return nodes;
+  }, [tree, path]);
+
+  const getParentNodes = useCallback(() => {
+    if (path.length === 0) return [];
+    let nodes = tree;
+    for (let i = 0; i < path.length - 1; i++) {
+      if (!nodes[path[i]]) return [];
+      nodes = nodes[path[i]].children || [];
+    }
+    return nodes;
+  }, [tree, path]);
+
+  const getBreadcrumb = useCallback(() => {
+    const crumbs = [];
+    let nodes = tree;
+    for (const idx of path) {
+      const node = nodes[idx];
+      if (!node) break;
+      crumbs.push((node.text || '').split('\n')[0]);
+      nodes = node.children || [];
+    }
+    return crumbs;
+  }, [tree, path]);
+
+  const currentNodes = getCurrentNodes();
+  const parentNodes = getParentNodes();
+  const parentSelectedIndex = path.length > 0 ? path[path.length - 1] : -1;
+  const breadcrumb = getBreadcrumb();
+  const selectedNode = currentNodes[selectedIndex];
+  const childNodes = selectedNode ? (selectedNode.children || []) : [];
+
+  const { sliderRef, animatingRef, slideNavigate } = useSlideAnimation(setPath, setSelectedIndex);
+  const { parentColRef, currentColRef, childColRef, leftSvgRef, rightSvgRef, leftLines, rightLines } = useSvgLines({
+    selectedIndex, path, tree,
+    childNodesLength: childNodes.length,
+    currentNodesLength: currentNodes.length,
+    parentNodesLength: parentNodes.length,
+  });
+
+  // Keyboard navigation (read-only).
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (animatingRef.current && (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'h' || e.key === 'l')) return;
+
+      switch (e.key) {
+        case 'ArrowUp':
+        case 'k':
+          e.preventDefault();
+          setSelectedIndex(i => Math.max(0, i - 1));
+          return;
+        case 'ArrowDown':
+        case 'j':
+          e.preventDefault();
+          setSelectedIndex(i => Math.min(currentNodes.length - 1, i + 1));
+          return;
+        case 'ArrowRight':
+        case 'l': {
+          e.preventDefault();
+          const sel = currentNodes[selectedIndex];
+          if (sel && sel.children && sel.children.length > 0) {
+            slideNavigate('right', [...path, selectedIndex], 0);
+          }
+          return;
+        }
+        case 'ArrowLeft':
+        case 'h':
+        case 'Backspace':
+          e.preventDefault();
+          if (path.length > 0) {
+            slideNavigate('left', path.slice(0, -1), path[path.length - 1]);
+          }
+          return;
+        case 'Escape':
+          e.preventDefault();
+          if (helpVisible) setHelpVisible(false);
+          else { setPath([]); setSelectedIndex(0); }
+          return;
+        case '?':
+          e.preventDefault();
+          setHelpVisible(v => !v);
+          return;
+        case 'Enter':
+        case 'i':
+        case 'x':
+        case 'c':
+        case 'q':
+        case 'd':
+        case 'm':
+          e.preventDefault();
+          showToast('Read-only snapshot');
+          return;
+        default:
+          return;
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [currentNodes, selectedIndex, path, slideNavigate, animatingRef, helpVisible, showToast]);
+
+  const exportedDate = exportedAt ? exportedAt.slice(0, 10) : '';
+  const sourceLabel = sourceUrl ? sourceUrl.replace(/^https?:\/\//, '') : '';
+
+  return (
+    <div className="app viewer-app">
+      {bannerVisible && (
+        <div className="viewer-banner">
+          <span className="viewer-banner-text">
+            Read-only snapshot &middot; Exported from Treenote
+            {exportedDate && <> &middot; {exportedDate}</>}
+            {sourceLabel && (
+              <> &middot; <a href={sourceUrl} target="_blank" rel="noopener noreferrer">{sourceLabel}</a></>
+            )}
+          </span>
+          <button
+            className="viewer-banner-dismiss"
+            onClick={() => setBannerVisible(false)}
+            aria-label="Dismiss banner"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
+      {breadcrumb.length > 0 && (
+        <div className="toolbar viewer-toolbar">
+          <div className="breadcrumb">
+            {breadcrumb.map((crumb, i) => (
+              <span key={i}>
+                {i > 0 && <span className="breadcrumb-separator"> &gt; </span>}
+                <span
+                  className={`breadcrumb-item ${i === breadcrumb.length - 1 ? 'current' : ''}`}
+                  onClick={() => {
+                    if (i < breadcrumb.length - 1) {
+                      const newPath = path.slice(0, i);
+                      const newSelected = path[i];
+                      if (i === breadcrumb.length - 2) {
+                        slideNavigate('left', newPath, newSelected);
+                      } else {
+                        setPath(newPath);
+                        setSelectedIndex(newSelected);
+                      }
+                    }
+                  }}
+                >
+                  {crumb}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {currentNodes.length === 0 ? (
+        <div className="empty-state">
+          <span className="empty-state-icon">&#8592;</span>
+          <span>Empty node &mdash; press <kbd>Left</kbd> to go back</span>
+        </div>
+      ) : (
+        <div className="columns-viewport">
+          <div className="columns" ref={sliderRef}>
+            {parentNodes.length > 0 ? (
+              <>
+                <div className="parent-list" ref={parentColRef}>
+                  {parentNodes.map((node, i) => (
+                    <div
+                      key={i}
+                      className={`parent-box ${i === parentSelectedIndex ? 'highlighted' : ''} ${node.checked ? 'checked' : ''}`}
+                      onClick={() => slideNavigate('left', path.slice(0, -1), i)}
+                    >
+                      <NodeContent text={node.text} markdown={node.markdown} />
+                      <NodeMeta node={node} />
+                    </div>
+                  ))}
+                </div>
+                <svg className="lines-svg" ref={leftSvgRef}>
+                  <defs>
+                    <linearGradient id="lineGradLeft" x1="0%" y1="0%" x2="100%" y2="0%">
+                      <stop offset="0%" stopColor="var(--line-color)" stopOpacity="0.15" />
+                      <stop offset="100%" stopColor="var(--line-color)" stopOpacity="0.4" />
+                    </linearGradient>
+                    <filter id="lineGlow">
+                      <feGaussianBlur stdDeviation="2" result="blur" />
+                      <feMerge>
+                        <feMergeNode in="blur" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                  </defs>
+                  {leftLines.map((l, i) => (
+                    <path
+                      key={i}
+                      d={`M 0 ${l.startY} C 30 ${l.startY}, 30 ${l.endY}, 60 ${l.endY}`}
+                      stroke="url(#lineGradLeft)"
+                      strokeWidth="1.5"
+                      fill="none"
+                      filter="url(#lineGlow)"
+                    />
+                  ))}
+                </svg>
+              </>
+            ) : (
+              <div className="column-spacer" />
+            )}
+
+            <div className="node-list" ref={currentColRef}>
+              {currentNodes.map((node, i) => {
+                const isSelected = i === selectedIndex;
+                return (
+                  <div
+                    key={i}
+                    className={`node-box ${isSelected ? 'selected' : ''} ${node.checked ? 'checked' : ''}`}
+                    onClick={() => setSelectedIndex(i)}
+                    onDoubleClick={() => {
+                      if ((node.children || []).length > 0) {
+                        slideNavigate('right', [...path, i], 0);
+                      }
+                    }}
+                  >
+                    <NodeMeta node={node} full />
+                    <NodeContent text={node.text} markdown={node.markdown} />
+                  </div>
+                );
+              })}
+            </div>
+
+            {childNodes.length > 0 && (
+              <>
+                <svg className="lines-svg" ref={rightSvgRef}>
+                  <defs>
+                    <linearGradient id="lineGradRight" x1="0%" y1="0%" x2="100%" y2="0%">
+                      <stop offset="0%" stopColor="var(--line-color)" stopOpacity="0.5" />
+                      <stop offset="100%" stopColor="var(--line-color)" stopOpacity="0.2" />
+                    </linearGradient>
+                  </defs>
+                  {rightLines.map((l, i) => (
+                    <path
+                      key={i}
+                      d={`M 0 ${l.startY} C 30 ${l.startY}, 30 ${l.endY}, 60 ${l.endY}`}
+                      stroke="url(#lineGradRight)"
+                      strokeWidth="1.5"
+                      fill="none"
+                      filter="url(#lineGlow)"
+                    />
+                  ))}
+                </svg>
+                <div className="child-list" ref={childColRef}>
+                  {childNodes.map((child, i) => (
+                    <div
+                      key={i}
+                      className={`child-box ${child.checked ? 'checked' : ''}`}
+                      onClick={() => slideNavigate('right', [...path, selectedIndex], i)}
+                    >
+                      <NodeContent text={child.text} markdown={child.markdown} />
+                      <NodeMeta node={child} />
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {toast && <div className="toast viewer-toast">{toast}</div>}
+
+      {helpVisible && (
+        <div className="viewer-help-overlay" onClick={() => setHelpVisible(false)}>
+          <div className="viewer-help-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="viewer-help-title">Read-only snapshot &mdash; keys</div>
+            <table className="viewer-help-table">
+              <tbody>
+                <tr><td>Move up/down</td><td><kbd>&uarr;</kbd>/<kbd>&darr;</kbd> or <kbd>j</kbd>/<kbd>k</kbd></td></tr>
+                <tr><td>Drill into node</td><td><kbd>&rarr;</kbd> or <kbd>l</kbd></td></tr>
+                <tr><td>Go back</td><td><kbd>&larr;</kbd>, <kbd>h</kbd>, or <kbd>Backspace</kbd></td></tr>
+                <tr><td>Back to root</td><td><kbd>Esc</kbd></td></tr>
+                <tr><td>Toggle this help</td><td><kbd>?</kbd></td></tr>
+              </tbody>
+            </table>
+            <div className="viewer-help-hint">Press <kbd>?</kbd> or click outside to dismiss.</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/viewer/main.jsx
+++ b/src/viewer/main.jsx
@@ -1,0 +1,27 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import Viewer from './Viewer';
+import '../theme.css';
+import '../App.css';
+import '../components/deadline.css';
+import './Viewer.css';
+
+// `window.__TREENOTE_DATA__` is injected by exportHtml.js right before this
+// script runs, replacing the <!--TREENOTE_DATA--> placeholder. If the file is
+// opened without injection (e.g. someone opens the raw template), fall back to
+// a tiny placeholder tree so we don't crash.
+const fallback = {
+  tree: [{ text: 'No data was injected into this template.', checked: false, children: [] }],
+  theme: 'dark',
+  boxWidth: 400,
+  exportedAt: new Date().toISOString(),
+  sourceUrl: '',
+};
+
+const data = (typeof window !== 'undefined' && window.__TREENOTE_DATA__) || fallback;
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <Viewer data={data} />
+  </StrictMode>
+);

--- a/src/viewer/viewer.html
+++ b/src/viewer/viewer.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Treenote — Read-only snapshot" />
+    <meta name="theme-color" content="#0d0d1a" />
+    <title>Treenote — Snapshot</title>
+    <!--
+      Note: The Inter font is fetched from Google Fonts when online. When the
+      exported file is opened offline, the system stack will be used instead
+      (handled in App.css's body font-family fallback). The look stays close
+      enough to the live app to be acceptable.
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.jsx"></script>
+    <!--TREENOTE_DATA-->
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   base: process.env.ELECTRON ? './' : '/',
+  // The viewer template lives in public/ and contains an inlined bundle. We
+  // don't want Vite's dep optimizer/scanner to crawl it (the inlined JS
+  // contains string literals like `<script type="module">` that confuse
+  // esbuild's HTML scanner). It's served as a static asset only.
+  optimizeDeps: {
+    entries: ['index.html', 'src/**/*.{js,jsx}'],
+  },
 });

--- a/vite.viewer.config.js
+++ b/vite.viewer.config.js
@@ -1,0 +1,79 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+
+// Single-file viewer build:
+//   - Inline every JS chunk into a <script type="module">…</script>.
+//   - Inline every CSS asset into a <style>…</style>.
+//   - Drop the resulting one-file HTML at public/viewer-template.html, where
+//     the main app can fetch('/viewer-template.html') at export time.
+// We deliberately preserve <!--TREENOTE_DATA--> — the runtime export path
+// substitutes the tree payload in there.
+function inlineAndEmit() {
+  return {
+    name: 'treenote-inline-and-emit',
+    enforce: 'post',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      const fileNames = Object.keys(bundle);
+      const htmlName = fileNames.find((n) => n.endsWith('.html'));
+      if (!htmlName) return;
+      const htmlAsset = bundle[htmlName];
+      let source = htmlAsset.source;
+
+      // Inline JS chunks.
+      for (const name of fileNames) {
+        const asset = bundle[name];
+        if (!asset || asset.type !== 'chunk') continue;
+        const escaped = asset.code.replace(/<\/script>/g, '<\\/script>');
+        const re = new RegExp(`<script[^>]*src="[^"]*${escapeRegex(name)}"[^>]*></script>`);
+        source = source.replace(re, `<script type="module">${escaped}</script>`);
+        delete bundle[name];
+      }
+
+      // Inline CSS assets.
+      for (const name of fileNames) {
+        const asset = bundle[name];
+        if (!asset || asset.type !== 'asset' || !name.endsWith('.css')) continue;
+        const css = typeof asset.source === 'string' ? asset.source : Buffer.from(asset.source).toString('utf-8');
+        const re = new RegExp(`<link[^>]*href="[^"]*${escapeRegex(name)}"[^>]*>`);
+        source = source.replace(re, `<style>${css}</style>`);
+        delete bundle[name];
+      }
+
+      // Write the consolidated artifact to public/.
+      const outDir = resolve(__dirname, 'public');
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(resolve(outDir, 'viewer-template.html'), source);
+
+      // Replace the bundled HTML so the throwaway dist-viewer/ also has it.
+      htmlAsset.fileName = 'viewer-template.html';
+      htmlAsset.source = source;
+      delete bundle[htmlName];
+      bundle['viewer-template.html'] = htmlAsset;
+    },
+  };
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export default defineConfig({
+  plugins: [react(), inlineAndEmit()],
+  root: resolve(__dirname, 'src/viewer'),
+  build: {
+    outDir: resolve(__dirname, 'dist-viewer'),
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    assetsInlineLimit: 100000000,
+    rollupOptions: {
+      input: resolve(__dirname, 'src/viewer/viewer.html'),
+      output: {
+        manualChunks: undefined,
+        inlineDynamicImports: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
Closes #61

Auto-generated fix by Claude Code agent.

## Issue
We need a design doc for a feature where I can just straight up export the current selected node as an HTML file that is self-contained, that has all the stuff rendered. but i can still like navigate it with the arrow keys but there's like the most of the code actually pertaining to tree note and all the back end is stripped away it's just html but i need to be able to like share that html file with others kind of does that make sense.

The design doc needs to encompass like UI, like how is that experience going to work without cluttering things? What button to click and then like also how does it work technically? Like how does the HTML file generation work there? I mean there has to be JavaScript inside I guess. We'd have to like embed React inside it as well as any like animation libraries that are there to give it the same experience or something. I don't know how that would work. I mean, I guess usually when render the page, that stuff is all packaged in anyway, so there has to be a technical route to get that to be done.

Create the deisgn doc in an md and we can iterate on this issue